### PR TITLE
Fixes #57: Record ChangeDiffs only for supported object types

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -1,4 +1,5 @@
 from netbox.plugins import PluginConfig
+from netbox.registry import registry
 
 
 class AppConfig(PluginConfig):
@@ -18,7 +19,14 @@ class AppConfig(PluginConfig):
 
     def ready(self):
         super().ready()
-        from . import events, search, signal_receivers
+        from . import constants, events, search, signal_receivers
+
+        # Record all object types which support branching in the NetBox registry
+        if 'branching' not in registry['model_features']:
+            registry['model_features']['branching'] = {
+                k: v for k, v in registry['model_features']['change_logging'].items()
+                if k not in constants.EXCLUDED_APPS
+            }
 
 
 config = AppConfig

--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -9,3 +9,9 @@ BRANCH_HEADER = 'X-NetBox-Branch'
 
 # URL query parameter name
 QUERY_PARAM = '_branch'
+
+# Apps which are explicitly excluded from branching
+EXCLUDED_APPS = (
+    'netbox_branching',
+    'netbox_changes',
+)

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -10,6 +10,7 @@ from core.choices import ObjectChangeActionChoices
 from core.models import ObjectChange, ObjectType
 from extras.events import process_event_rules
 from extras.models import EventRule
+from netbox.registry import registry
 from utilities.exceptions import AbortRequest
 from utilities.serialization import serialize_object
 from .choices import BranchStatusChoices
@@ -33,6 +34,10 @@ def record_change_diff(instance, **kwargs):
     branch = active_branch.get()
     object_type = instance.changed_object_type
     object_id = instance.changed_object_id
+
+    # If this type of object does not support branching, return immediately.
+    if object_type.model not in registry['model_features']['branching'].get(object_type.app_label, []):
+        return
 
     # If this is a global change, update the "current" state in any ChangeDiffs for this object.
     if branch is None:

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -73,9 +73,8 @@ def get_branchable_object_types():
     Return all object types which are branch-aware; i.e. those which support change logging.
     """
     from core.models import ObjectType
-    return ObjectType.objects.with_feature('change_logging').exclude(
-        app_label__in=['netbox_branching', 'netbox_changes']
-    )
+
+    return ObjectType.objects.with_feature('branching')
 
 
 def get_tables_to_replicate():


### PR DESCRIPTION
### Fixes: #57

- Move excluded apps to a constant
- Add an entry for `branching` in the model features registry
- Modify `record_change_diff()` to skip unsupported object types