### PR TITLE
Closes #52: Introduce the `max_branches` config parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@
 
 Default: None
 
-The maximum number of branches that can be provisioned simultaneously. This includes merged branches that have not been deleted.
+The maximum number of branches that can exist simultaneously, including merged branches that have not been deleted. It may be desirable to limit the total number of provisioned branches to safeguard against excessive database size.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,17 @@
+# Configuration Parameters
+
+## `max_branches`
+
+Default: None
+
+The maximum number of branches that can be provisioned simultaneously. This includes merged branches that have not been deleted.
+
+---
+
+## `schema_prefix`
+
+Default: `branch_`
+
+The string to prefix to the unique branch ID when provisioning the PostgreSQL schema for a branch. Per [the PostgreSQL documentation](https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), this string must begin with a letter or underscore.
+
+Note that a valid prefix is required, as the randomly-generated branch ID alone may begin with a digit, which would not qualify as a valid schema name.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
         - Syncing & Merging: 'using-branches/syncing-merging.md'
         - Reverting a Branch: 'using-branches/reverting-a-branch.md'
     - REST API: 'rest-api.md'
+    - Configuration: 'configuration.md'
     - Data Model:
         - Branch: 'models/branch.md'
         - BranchEvent: 'models/branchevent.md'

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -13,6 +13,9 @@ class AppConfig(PluginConfig):
         'netbox_branching.middleware.BranchMiddleware'
     ]
     default_settings = {
+        # The maximum number of branches which can be provisioned simultaneously
+        'max_branches': None,
+
         # This string is prefixed to the name of each new branch schema during provisioning
         'schema_prefix': 'branch_',
     }


### PR DESCRIPTION
### Closes: #52

- Introduce the `max_branches` configuration parameter to limit the total number of branches
- Add a page in the documentation for configuration parameters