### PR TITLE
Fixes #59: `BranchAwareRouter` should disregard models which do not support branching

### DIFF
--- a/netbox_branching/database.py
+++ b/netbox_branching/database.py
@@ -1,3 +1,5 @@
+from netbox.registry import registry
+
 from .contextvars import active_branch
 
 
@@ -11,15 +13,21 @@ class BranchAwareRouter:
     A Django database router that returns the appropriate connection/schema for
     the active branch (if any).
     """
-    def db_for_read(self, model, **hints):
+    def _get_db(self, model, **hints):
+        # Bail if the model does not support branching
+        app_label, model_name = model._meta.label.lower().split('.')
+        if model_name not in registry['model_features']['branching'].get(app_label, []):
+            return
+
+        # Return the schema for the active branch (if any)
         if branch := active_branch.get():
             return f'schema_{branch.schema_name}'
-        return None
+
+    def db_for_read(self, model, **hints):
+        return self._get_db(model, **hints)
 
     def db_for_write(self, model, **hints):
-        if branch := active_branch.get():
-            return f'schema_{branch.schema_name}'
-        return None
+        return self._get_db(model, **hints)
 
     def allow_relation(self, obj1, obj2, **hints):
         # Permit relations from the branch schema to the main (public) schema


### PR DESCRIPTION
### Fixes: #59

- Move database name resolution logic to a new `_get_db()` method
- Return null if the model is not registered as supporting branching