### PR TITLE
Fixes #61: Fix transaction rollback when performing a dry run sync

### DIFF
--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -249,7 +249,7 @@ class Branch(JobsMixin, PrimaryModel):
                     # Apply each change from the main schema
                     for change in self.get_unsynced_changes().order_by('time'):
                         logger.debug(f'Applying change: {change}')
-                        change.apply(using=self.connection_name)
+                        change.apply()
                     if not commit:
                         raise AbortTransaction()
 


### PR DESCRIPTION
### Fixes: #61

Remove the explicit connection specifier (`using`) for `change.apply()` to ensure we stay inside the atomic transaction wrapper.