### PR TITLE
Fixes #66: Capture object representation on ChangeDiff when creating a new object within a branch

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -75,8 +75,7 @@ def record_change_diff(instance, **kwargs):
                 current_data = serialize_object(obj, exclude=['created', 'last_updated'])
             diff = ChangeDiff(
                 branch=branch,
-                object_type=instance.changed_object_type,
-                object_id=instance.changed_object_id,
+                object=instance.changed_object,
                 action=instance.action,
                 original=instance.prechange_data_clean,
                 modified=instance.postchange_data_clean,


### PR DESCRIPTION
### Fixes: #66

Assign the object itself to the ChangeDiff, rather than just its type & ID, to ensure the instance can be cast to a string for the `object_repr` field.