### PR TITLE
Closes #68: Replace ruff with pycodestyle

### DIFF
--- a/.github/workflows/lint-tests.yaml
+++ b/.github/workflows/lint-tests.yaml
@@ -34,10 +34,9 @@ jobs:
           pip install .[test]
       - name: Build documentation
         run: mkdocs build
-      - name: Lint with Ruff
+      - name: Run pycodestyle
         run: |
-          ruff check --output-format=github netbox_branching/
-        continue-on-error: true
+          pycodestyle --ignore=W504,E501 netbox_branching/
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["black", "check-manifest", "ruff", "mkdocs", "mkdocs-material"]
+dev = ["check-manifest", "mkdocs", "mkdocs-material", "pycodestyle"]
 test = ["coverage", "pytest", "pytest-cov"]
 
 [project.urls]
@@ -47,23 +47,3 @@ license-files = ["LICENSE.md"]
 [build-system]
 requires = ["setuptools>=43.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[tool.ruff]
-line-length = 140
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-
-[tool.ruff.lint]
-select = ["C", "D", "E", "F", "I", "R", "UP", "W"]
-ignore = [
-    "F401",
-    "D203",
-    "D212",
-    "D400",
-    "D401",
-    "D404",
-    "RET504",
-    "D1"
-]


### PR DESCRIPTION
### Fixes: #68

- Replace `ruff` with `pycodestyle`
- Style violations will now cause the job to fail