### PR TITLE
Closes #76: Check for required settings on init

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
 from netbox.plugins import PluginConfig
 from netbox.registry import registry
 
@@ -23,6 +26,17 @@ class AppConfig(PluginConfig):
     def ready(self):
         super().ready()
         from . import constants, events, search, signal_receivers
+        from .utilities import DynamicSchemaDict
+
+        # Validate required settings
+        if type(settings.DATABASES) is not DynamicSchemaDict:
+            raise ImproperlyConfigured(
+                "netbox_branching: DATABASES must be a DynamicSchemaDict instance."
+            )
+        if 'netbox_branching.database.BranchAwareRouter' not in settings.DATABASE_ROUTERS:
+            raise ImproperlyConfigured(
+                "netbox_branching: DATABASE_ROUTERS must contain 'netbox_branching.database.BranchAwareRouter'."
+            )
 
         # Record all object types which support branching in the NetBox registry
         if 'branching' not in registry['model_features']:


### PR DESCRIPTION
### Closes: #76

Validate that `DATABASES` and `DATABASE_ROUTERS` have been configured as required on init.
