### PR TITLE
Closes #84: Introduce the `max_active_branches` config parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 # Configuration Parameters
 
-## `max_active_branches`
+## `max_working_branches`
 
 Default: None
 
-The maximum number of _active_ branches that can exist simultaneously. This count excludes branches which have been merged or archived.
+The maximum number of operational branches that can exist simultaneously. This count excludes branches which have been merged or archived.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,18 @@
 # Configuration Parameters
 
+## `max_active_branches`
+
+Default: None
+
+The maximum number of _active_ branches that can exist simultaneously. This count excludes branches which have been merged or archived.
+
+---
+
 ## `max_branches`
 
 Default: None
 
-The maximum number of branches that can exist simultaneously, including merged branches that have not been deleted. It may be desirable to limit the total number of provisioned branches to safeguard against excessive database size.
+The maximum total number of branches that can exist simultaneously, including merged branches that have not been deleted. It may be desirable to limit the total number of provisioned branches to safeguard against excessive database size.
 
 ---
 

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -16,6 +16,9 @@ class AppConfig(PluginConfig):
         'netbox_branching.middleware.BranchMiddleware'
     ]
     default_settings = {
+        # The maximum number of active branches (excludes merged & archived branches)
+        'max_active_branches': None,
+
         # The maximum number of branches which can be provisioned simultaneously
         'max_branches': None,
 

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -16,8 +16,8 @@ class AppConfig(PluginConfig):
         'netbox_branching.middleware.BranchMiddleware'
     ]
     default_settings = {
-        # The maximum number of active branches (excludes merged & archived branches)
-        'max_active_branches': None,
+        # The maximum number of working branches (excludes merged & archived branches)
+        'max_working_branches': None,
 
         # The maximum number of branches which can be provisioned simultaneously
         'max_branches': None,

--- a/netbox_branching/choices.py
+++ b/netbox_branching/choices.py
@@ -28,7 +28,13 @@ class BranchStatusChoices(ChoiceSet):
         PROVISIONING,
         SYNCING,
         MERGING,
-        REVERTING
+        REVERTING,
+    )
+
+    ACTIVE_STATUSES = (
+        NEW,
+        READY,
+        *TRANSITIONAL,
     )
 
 

--- a/netbox_branching/choices.py
+++ b/netbox_branching/choices.py
@@ -33,7 +33,7 @@ class BranchStatusChoices(ChoiceSet):
         REVERTING,
     )
 
-    ACTIVE_STATUSES = (
+    WORKING = (
         NEW,
         READY,
         *TRANSITIONAL,

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -144,8 +144,8 @@ class Branch(JobsMixin, PrimaryModel):
             if working_branch_count >= max_working_branches:
                 raise ValidationError(
                     _(
-                        "The configured maximum number of active branches ({max}) cannot be exceeded. One or more "
-                        "active branches must be archived or deleted before a new branch may be created."
+                        "The configured maximum number of working branches ({max}) cannot be exceeded. One or more "
+                        "working branches must be merged or archived before a new branch may be created."
                     ).format(max=max_working_branches)
                 )
 

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -139,14 +139,14 @@ class Branch(JobsMixin, PrimaryModel):
                 )
 
         # Enforce the maximum number of active branches
-        if not self.pk and (max_active_branches := get_plugin_config('netbox_branching', 'max_active_branches')):
-            active_branch_count = Branch.objects.filter(status__in=BranchStatusChoices.ACTIVE_STATUSES).count()
-            if active_branch_count >= max_active_branches:
+        if not self.pk and (max_working_branches := get_plugin_config('netbox_branching', 'max_working_branches')):
+            working_branch_count = Branch.objects.filter(status__in=BranchStatusChoices.WORKING).count()
+            if working_branch_count >= max_working_branches:
                 raise ValidationError(
                     _(
                         "The configured maximum number of active branches ({max}) cannot be exceeded. One or more "
                         "active branches must be archived or deleted before a new branch may be created."
-                    ).format(max=max_active_branches)
+                    ).format(max=max_working_branches)
                 )
 
     def save(self, provision=True, *args, **kwargs):

--- a/netbox_branching/template_content.py
+++ b/netbox_branching/template_content.py
@@ -17,9 +17,7 @@ class BranchSelector(PluginTemplateExtension):
     def navbar(self):
         return self.render('netbox_branching/inc/branch_selector.html', extra_context={
             'active_branch': active_branch.get(),
-            'branches': Branch.objects.exclude(
-                status__in=[BranchStatusChoices.MERGED, BranchStatusChoices.ARCHIVED]
-            ),
+            'branches': Branch.objects.filter(status__in=BranchStatusChoices.WORKING),
         })
 
 

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -80,12 +80,12 @@ class BranchTestCase(TransactionTestCase):
 
     @override_settings(PLUGINS_CONFIG={
         'netbox_branching': {
-            'max_active_branches': 2,
+            'max_working_branches': 2,
         }
     })
-    def test_max_active_branches(self):
+    def test_max_working_branches(self):
         """
-        Verify that the max_active_branches config parameter is enforced.
+        Verify that the max_working_branches config parameter is enforced.
         """
         Branch.objects.bulk_create((
             Branch(name='Branch 1', status=BranchStatusChoices.MERGED),

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import connection
 from django.test import TransactionTestCase, override_settings
 
+from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.constants import MAIN_SCHEMA
 from netbox_branching.models import Branch
 from netbox_branching.utilities import get_tables_to_replicate
@@ -76,6 +77,30 @@ class BranchTestCase(TransactionTestCase):
         branch.save(provision=False)
         branch.refresh_from_db()
         self.assertEqual(branch.schema_id, schema_id, msg="Schema ID was changed during save()")
+
+    @override_settings(PLUGINS_CONFIG={
+        'netbox_branching': {
+            'max_active_branches': 2,
+        }
+    })
+    def test_max_active_branches(self):
+        """
+        Verify that the max_active_branches config parameter is enforced.
+        """
+        Branch.objects.bulk_create((
+            Branch(name='Branch 1', status=BranchStatusChoices.MERGED),
+            Branch(name='Branch 2', status=BranchStatusChoices.READY),
+        ))
+
+        # Second active branch should be permitted (merged branches don't count)
+        branch = Branch(name='Branch 3')
+        branch.full_clean()
+        branch.save()
+
+        # Attempting to create a third active branch should fail
+        branch = Branch(name='Branch 4')
+        with self.assertRaises(ValidationError):
+            branch.full_clean()
 
     @override_settings(PLUGINS_CONFIG={
         'netbox_branching': {


### PR DESCRIPTION
### Fixes: #84

- Introduce the `max_active_branches` config parameter
- Enforce it upon the creation of each new Branch