### PR TITLE
88 enable branching in graphql

### DIFF
--- a/netbox_branching/middleware.py
+++ b/netbox_branching/middleware.py
@@ -46,7 +46,10 @@ class BranchMiddleware:
         Return the active Branch (if any).
         """
         # The active Branch is specified by HTTP header for REST API requests.
-        if request.path_info.startswith(reverse('api-root')) and (schema_id := request.headers.get(BRANCH_HEADER)):
+        if (
+            request.path_info.startswith(reverse('api-root')) or (
+                request.path_info.startswith(reverse('graphql')))) and (
+                schema_id := request.headers.get(BRANCH_HEADER)):
             branch = Branch.objects.get(schema_id=schema_id)
             if not branch.ready:
                 return HttpResponseBadRequest(f"Branch {branch} is not ready for use (status: {branch.status})")


### PR DESCRIPTION
### Fixes: #88

Test used the following query with and without the X-NetBox-Branch line:
```
curl -H "Authorization: Token $TOKEN" \
-H "Content-Type: application/json" \
-H "Accept: application/json" \
-H "X-NetBox-Branch: 1nrbxwdu" \
http://127.0.0.1:8000/graphql/ \
--data '{"query": "query {site_list {id name}}"}'
```