### PR TITLE
Closes #97: Introduce the `exempt_models` config parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,30 @@
 # Configuration Parameters
 
+## `exempt_models`
+
+Default: `[]` (empty list)
+
+A list of models provided by other plugins which should be exempt from branching support. (Only models which support change logging need be listed; all other models are ineligible for branching support.)
+
+Models must be specified by app label and model name, as such:
+
+```python
+exempt_models = (
+    'my_plugin.foo',
+    'my_plugin.bar',
+)
+```
+
+It is also possible to exclude _all_ models from within a plugin by substituting an asterisk (`*`) for the model name:
+
+```python
+exempt_models = (
+    'my_plugin.*',
+)
+```
+
+---
+
 ## `max_working_branches`
 
 Default: None

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,9 @@ Default: `[]` (empty list)
 
 A list of models provided by other plugins which should be exempt from branching support. (Only models which support change logging need be listed; all other models are ineligible for branching support.)
 
+!!! warning
+    A model may not be exempted from branching support if it has one or more relationships to models for which branching is supported. Branching **must** be supported consistently for all inter-related models; otherwise, data corruption can occur. Configure this setting only if you have a specific need to disable branching for certain models provided by plugins.
+
 Models must be specified by app label and model name, as such:
 
 ```python

--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -10,8 +10,8 @@ BRANCH_HEADER = 'X-NetBox-Branch'
 # URL query parameter name
 QUERY_PARAM = '_branch'
 
-# Apps which are explicitly excluded from branching
-EXCLUDED_APPS = (
-    'netbox_branching',
-    'netbox_changes',
+# Models for which branching support is explicitly disabled
+EXEMPT_MODELS = (
+    'netbox_branching.*',
+    'netbox_changes.*',
 )


### PR DESCRIPTION
### Fixes: #97

- Introduce the `exempt_models` config parameter
- Change the `EXCLUDED_APPS` constant to `EXEMPT_MODELS`
- Tweak plugin initialization logic to inspect both static & configured exempt models

