### PR TITLE
Fixes: #83 - Add Share button for object views when a branch is selected

### DIFF
--- a/netbox_branching/template_content.py
+++ b/netbox_branching/template_content.py
@@ -21,6 +21,14 @@ class BranchSelector(PluginTemplateExtension):
         })
 
 
+class ShareButton(PluginTemplateExtension):
+
+    def buttons(self):
+        return self.render('netbox_branching/inc/share_button.html', extra_context={
+            'active_branch': active_branch.get(),
+        })
+
+
 class BranchNotification(PluginTemplateExtension):
 
     def alerts(self):
@@ -43,4 +51,4 @@ class BranchNotification(PluginTemplateExtension):
         })
 
 
-template_extensions = [BranchSelector, BranchNotification]
+template_extensions = [BranchSelector, ShareButton, BranchNotification]

--- a/netbox_branching/templates/netbox_branching/inc/share_button.html
+++ b/netbox_branching/templates/netbox_branching/inc/share_button.html
@@ -1,6 +1,6 @@
 {% if active_branch %}
     {% load i18n %}
-    <a href="{{ url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue">
+    <a href="{{ object.get_absolute_url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue">
         <i class="mdi mdi-share"></i> {% trans "Share" %}
     </a>
 {% endif %}

--- a/netbox_branching/templates/netbox_branching/inc/share_button.html
+++ b/netbox_branching/templates/netbox_branching/inc/share_button.html
@@ -1,0 +1,6 @@
+{% if active_branch %}
+    {% load i18n %}
+    <a href="{{ url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue">
+        <i class="mdi mdi-share"></i> {% trans "Share" %}
+    </a>
+{% endif %}

--- a/netbox_branching/templates/netbox_branching/inc/share_button.html
+++ b/netbox_branching/templates/netbox_branching/inc/share_button.html
@@ -1,6 +1,6 @@
 {% if active_branch %}
     {% load i18n %}
-    <a href="{{ object.get_absolute_url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue">
+    <a href="{{ object.get_absolute_url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue" title="{% trans "Link to the this page in the current branch" %} ({{ active_branch.name }})">
         <i class="mdi mdi-share"></i> {% trans "Share" %}
     </a>
 {% endif %}


### PR DESCRIPTION
### Fixes: #83

Adds a Share button on all object detail pages when a branch other than Main is selected. Button color and placement is TBD (seems like it should be grouped with Bookmark).

<img width="1175" alt="Screenshot 2024-09-10 at 6 22 11 PM" src="https://github.com/user-attachments/assets/275fc3be-0247-4d4f-8c46-44e601f4c920">
