### PR TITLE
Fixes #120: `max_branches` should disregard archived branches

### DIFF
--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -129,12 +129,12 @@ class Branch(JobsMixin, PrimaryModel):
 
         # Enforce the maximum number of total branches
         if not self.pk and (max_branches := get_plugin_config('netbox_branching', 'max_branches')):
-            total_branch_count = Branch.objects.count()
+            total_branch_count = Branch.objects.exclude(status=BranchStatusChoices.ARCHIVED).count()
             if total_branch_count >= max_branches:
                 raise ValidationError(
                     _(
-                        "The configured maximum number of branches ({max}) cannot be exceeded. One or more existing "
-                        "branches must be deleted before a new branch may be created."
+                        "The configured maximum number of non-archived branches ({max}) cannot be exceeded. One or "
+                        "more existing branches must be deleted before a new branch may be created."
                     ).format(max=max_branches)
                 )
 

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -112,10 +112,16 @@ class BranchTestCase(TransactionTestCase):
         Verify that the max_branches config parameter is enforced.
         """
         Branch.objects.bulk_create((
-            Branch(name='Branch 1'),
-            Branch(name='Branch 2'),
+            Branch(name='Branch 1', status=BranchStatusChoices.ARCHIVED),
+            Branch(name='Branch 2', status=BranchStatusChoices.READY),
         ))
 
+        # Creating a second non-archived Branch should succeed
         branch = Branch(name='Branch 3')
+        branch.full_clean()
+        branch.save(provision=False)
+
+        # Creating a third non-archived Branch should fail
+        branch = Branch(name='Branch 4')
         with self.assertRaises(ValidationError):
             branch.full_clean()


### PR DESCRIPTION
### Fixes: #120

Ignore archived branches when enforcing the `max_branches` config parameter.
