### PR TITLE
Closes #129: Introduce pre-event signals for branch actions

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -124,11 +124,11 @@ def handle_branch_event(event_type, branch, user=None, **kwargs):
     )
 
 
-branch_provisioned.connect(partial(handle_branch_event, event_type=BRANCH_PROVISIONED))
-branch_synced.connect(partial(handle_branch_event, event_type=BRANCH_SYNCED))
-branch_merged.connect(partial(handle_branch_event, event_type=BRANCH_MERGED))
-branch_reverted.connect(partial(handle_branch_event, event_type=BRANCH_REVERTED))
-branch_deprovisioned.connect(partial(handle_branch_event, event_type=BRANCH_DEPROVISIONED))
+post_provision.connect(partial(handle_branch_event, event_type=BRANCH_PROVISIONED))
+post_deprovision.connect(partial(handle_branch_event, event_type=BRANCH_DEPROVISIONED))
+post_sync.connect(partial(handle_branch_event, event_type=BRANCH_SYNCED))
+post_merge.connect(partial(handle_branch_event, event_type=BRANCH_MERGED))
+post_revert.connect(partial(handle_branch_event, event_type=BRANCH_REVERTED))
 
 
 @receiver(pre_delete, sender=Branch)

--- a/netbox_branching/signals.py
+++ b/netbox_branching/signals.py
@@ -1,26 +1,28 @@
 from django.dispatch import Signal
 
-from .events import *
-
 __all__ = (
-    'branch_deprovisioned',
-    'branch_merged',
-    'branch_provisioned',
-    'branch_reverted',
-    'branch_synced',
+    'post_deprovision',
+    'post_merge',
+    'post_provision',
+    'post_revert',
+    'post_sync',
+    'pre_deprovision',
+    'pre_merge',
+    'pre_provision',
+    'pre_revert',
+    'pre_sync',
 )
 
+# Pre-event signals
+pre_provision = Signal()
+pre_deprovision = Signal()
+pre_sync = Signal()
+pre_merge = Signal()
+pre_revert = Signal()
 
-branch_provisioned = Signal()
-branch_deprovisioned = Signal()
-branch_synced = Signal()
-branch_merged = Signal()
-branch_reverted = Signal()
-
-branch_signals = {
-    branch_provisioned: BRANCH_PROVISIONED,
-    branch_deprovisioned: BRANCH_DEPROVISIONED,
-    branch_synced: BRANCH_SYNCED,
-    branch_merged: BRANCH_MERGED,
-    branch_reverted: BRANCH_REVERTED,
-}
+# Post-event signals
+post_provision = Signal()
+post_deprovision = Signal()
+post_sync = Signal()
+post_merge = Signal()
+post_revert = Signal()


### PR DESCRIPTION
### Closes: #129

- Rename post-event signals
- Add pre-event signals
- Remove unused variable `branch_signals`