### PR TITLE
Fixes #98: Cable changes in branch should not impact main schema

### DIFF
--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -10,6 +10,12 @@ BRANCH_HEADER = 'X-NetBox-Branch'
 # URL query parameter name
 QUERY_PARAM = '_branch'
 
+# Tables which must be replicated within a branch even though their
+# models don't directly support branching.
+REPLICATE_TABLES = (
+    'dcim_cablepath',
+)
+
 # Models for which branching support is explicitly disabled
 EXEMPT_MODELS = (
     # Exempt applicable core NetBox models

--- a/netbox_branching/database.py
+++ b/netbox_branching/database.py
@@ -21,11 +21,6 @@ class BranchAwareRouter:
             warnings.warn(f"Routing database query for {model} before branching support is initialized.")
             return
 
-        # Bail if the model does not support branching
-        app_label, model_name = model._meta.label.lower().split('.')
-        if model_name not in registry['model_features']['branching'].get(app_label, []):
-            return
-
         # Return the schema for the active branch (if any)
         if branch := active_branch.get():
             return f'schema_{branch.schema_name}'

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from django.db.models import ForeignKey, ManyToManyField
 from django.urls import reverse
 
+from .constants import REPLICATE_TABLES
 from .contextvars import active_branch
 
 __all__ = (
@@ -81,9 +82,9 @@ def get_branchable_object_types():
 
 def get_tables_to_replicate():
     """
-    Returned an ordered list of database tables to replicate when provisioning a new schema.
+    Return an ordered list of database tables to replicate when provisioning a new schema.
     """
-    tables = set()
+    tables = set(REPLICATE_TABLES)
 
     branch_aware_models = [
         ot.model_class() for ot in get_branchable_object_types()


### PR DESCRIPTION
### Fixes: #98

Replicate the `dcim_cablepath` table when provisioning a branch to ensure cable changes do not interfere with the main schema.