### PR TITLE
Fixes #163: Ensure changelog records for non-branching models are created in main schema

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from netbox.plugins import PluginConfig, get_plugin_config
-from netbox.registry import registry
+from netbox.plugins import PluginConfig
+from .utilities import register_models
 
 
 class AppConfig(PluginConfig):
@@ -44,23 +44,8 @@ class AppConfig(PluginConfig):
                 "netbox_branching: DATABASE_ROUTERS must contain 'netbox_branching.database.BranchAwareRouter'."
             )
 
-        # Record all object types which support branching in the NetBox registry
-        exempt_models = (
-            *constants.EXEMPT_MODELS,
-            *get_plugin_config('netbox_branching', 'exempt_models'),
-        )
-        branching_models = {}
-        for app_label, models in registry['model_features']['change_logging'].items():
-            # Wildcard exclusion for all models in this app
-            if f'{app_label}.*' in exempt_models:
-                continue
-            models = [
-                model for model in models
-                if f'{app_label}.{model}' not in exempt_models
-            ]
-            if models:
-                branching_models[app_label] = models
-        registry['model_features']['branching'] = branching_models
+        # Register models which support branching
+        register_models()
 
 
 config = AppConfig

--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -10,10 +10,10 @@ BRANCH_HEADER = 'X-NetBox-Branch'
 # URL query parameter name
 QUERY_PARAM = '_branch'
 
-# Tables which must be replicated within a branch even though their
-# models don't directly support branching.
-REPLICATE_TABLES = (
-    'dcim_cablepath',
+# Models which do not support change logging, but whose database tables
+# must be replicated for each branch to ensure proper functionality
+INCLUDE_MODELS = (
+    'dcim.cablepath',
 )
 
 # Models for which branching support is explicitly disabled

--- a/netbox_branching/database.py
+++ b/netbox_branching/database.py
@@ -21,6 +21,11 @@ class BranchAwareRouter:
             warnings.warn(f"Routing database query for {model} before branching support is initialized.")
             return
 
+        # Bail if the model does not support branching
+        app_label, model_name = model._meta.label.lower().split('.')
+        if model_name not in registry['model_features']['branching'].get(app_label, []):
+            return
+
         # Return the schema for the active branch (if any)
         if branch := active_branch.get():
             return f'schema_{branch.schema_name}'


### PR DESCRIPTION
### Fixes: #163

- Move model registration to a utility function (housekeeping)
- Revert the removal of database router logic from the fix for #98 (fixes this bug)
- Declare branching support for the CablePath model (alternate fix for #98)
