### PR TITLE
Closes #189: Introduce a mechanism to automatically register pre-action branch validators

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -54,6 +54,9 @@ class AppConfig(PluginConfig):
                 "netbox_branching: DATABASE_ROUTERS must contain 'netbox_branching.database.BranchAwareRouter'."
             )
 
+        # Register models which support branching
+        register_models()
+
         # Validate & register configured branch action validators
         for action in BRANCH_ACTIONS:
             for validator_path in get_plugin_config('netbox_branching', f'{action}_validators'):
@@ -62,9 +65,6 @@ class AppConfig(PluginConfig):
                 except ImportError:
                     raise ImproperlyConfigured(f"Branch {action} validator not found: {validator_path}")
                 Branch.register_preaction_check(func, action)
-
-        # Register models which support branching
-        register_models()
 
 
 config = AppConfig

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -53,9 +53,6 @@ class AppConfig(PluginConfig):
                 "netbox_branching: DATABASE_ROUTERS must contain 'netbox_branching.database.BranchAwareRouter'."
             )
 
-        # Register models which support branching
-        register_models()
-
         # Validate branch action validators
         for action in BRANCH_ACTIONS:
             for validator_path in get_plugin_config('netbox_branching', f'{action}_validators'):
@@ -63,6 +60,9 @@ class AppConfig(PluginConfig):
                     import_string(validator_path)
                 except ImportError:
                     raise ImproperlyConfigured(f"Branch {action} validator not found: {validator_path}")
+
+        # Register models which support branching
+        register_models()
 
 
 config = AppConfig

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -41,6 +41,7 @@ class AppConfig(PluginConfig):
     def ready(self):
         super().ready()
         from . import constants, events, search, signal_receivers
+        from .models import Branch
         from .utilities import DynamicSchemaDict
 
         # Validate required settings
@@ -53,13 +54,14 @@ class AppConfig(PluginConfig):
                 "netbox_branching: DATABASE_ROUTERS must contain 'netbox_branching.database.BranchAwareRouter'."
             )
 
-        # Validate branch action validators
+        # Validate & register configured branch action validators
         for action in BRANCH_ACTIONS:
             for validator_path in get_plugin_config('netbox_branching', f'{action}_validators'):
                 try:
-                    import_string(validator_path)
+                    func = import_string(validator_path)
                 except ImportError:
                     raise ImproperlyConfigured(f"Branch {action} validator not found: {validator_path}")
+                Branch.register_preaction_check(func, action)
 
         # Register models which support branching
         register_models()

--- a/netbox_branching/templates/netbox_branching/branch_action.html
+++ b/netbox_branching/templates/netbox_branching/branch_action.html
@@ -20,9 +20,8 @@
     {% if not action_permitted %}
       <div class="alert alert-warning">
         <i class="mdi mdi-alert-circle"></i>
-        {% blocktrans %}
-          This action is disallowed per policy, however dry runs are permitted.
-        {% endblocktrans %}
+        {{ action_permitted.message }}
+        {% blocktrans %}Only dry runs are permitted.{% endblocktrans %}
       </div>
     {% endif %}
     {% if conflicts_table.rows %}

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -17,6 +17,7 @@ from .constants import BRANCH_HEADER, COOKIE_NAME, EXEMPT_MODELS, INCLUDE_MODELS
 from .contextvars import active_branch
 
 __all__ = (
+    'BranchActionIndicator',
     'ChangeSummary',
     'DynamicSchemaDict',
     'ListHandler',
@@ -261,3 +262,15 @@ def ActiveBranchContextManager(request):
     if branch := get_active_branch(request):
         return activate_branch(branch)
     return nullcontext()
+
+
+@dataclass
+class BranchActionIndicator:
+    """
+    An indication of whether a particular branch action is permitted. If not, an explanatory message must be provided.
+    """
+    permitted: bool
+    message: str = ''
+
+    def __bool__(self):
+        return self.permitted


### PR DESCRIPTION
### Closes: #189

- Adds the `register_preaction_check()` class method on Branch
- Introduces BranchActionIndicator to enable conveying an explanatory message for validation failures
- Configured validators are now imported only once, at initialization
- All `can_*` methods on Branch are now cached properties