### PR TITLE
Closes #209: Prevent stale branches from being synced

### DIFF
--- a/docs/using-branches/syncing-merging.md
+++ b/docs/using-branches/syncing-merging.md
@@ -6,6 +6,9 @@ Synchronizing a branch replicates all recent changes from main into the branch. 
 
 To synchronize a branch, click the "Sync" button. (If this button is not visible, verify that the branch status shows "ready" and that you have permission to synchronize the branch.)
 
+!!! warning
+    A branch must be synchronized frequently enough to avoid exceeding NetBox's configured [changelog retention period](https://netboxlabs.com/docs/netbox/en/stable/configuration/miscellaneous/#changelog_retention) (which defaults to 90 days). This is to protect against data loss when replicating changes from main. A branch whose `last_sync` time exceeds the configured retention window can no longer be synced.
+
 While a branch is being synchronized, its status will show "synchronizing."
 
 !!! tip

--- a/netbox_branching/tables/tables.py
+++ b/netbox_branching/tables/tables.py
@@ -56,8 +56,16 @@ class BranchTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    is_active = columns.BooleanColumn(
+        verbose_name=_('Active')
+    )
     status = columns.ChoiceFieldColumn(
-        verbose_name=_('Status'),
+        verbose_name=_('Status')
+    )
+    is_stale = columns.BooleanColumn(
+        true_mark=mark_safe('<span class="text-danger"><i class="mdi mdi-alert-circle"></i></span>'),
+        false_mark=None,
+        verbose_name=_('Stale')
     )
     conflicts = ConflictsColumn(
         verbose_name=_('Conflicts')
@@ -72,11 +80,11 @@ class BranchTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Branch
         fields = (
-            'pk', 'id', 'name', 'is_active', 'status', 'conflicts', 'schema_id', 'description', 'owner', 'tags',
-            'created', 'last_updated',
+            'pk', 'id', 'name', 'is_active', 'status', 'is_stale', 'conflicts', 'schema_id', 'description', 'owner',
+            'tags', 'created', 'last_updated',
         )
         default_columns = (
-            'pk', 'name', 'is_active', 'status', 'owner', 'conflicts', 'schema_id', 'description',
+            'pk', 'name', 'is_active', 'status', 'is_stale', 'owner', 'conflicts', 'schema_id', 'description',
         )
 
     def render_is_active(self, value):

--- a/netbox_branching/templates/netbox_branching/branch.html
+++ b/netbox_branching/templates/netbox_branching/branch.html
@@ -82,11 +82,24 @@
           </tr>
           <tr>
             <th scope="row">{% trans "Last synced" %}</th>
-            <td>{{ object.synced_time|isodatetime }}</td>
+            <td>
+              {{ object.synced_time|isodatetime }}
+              {% if object.is_stale %}
+                <span class="text-danger" title="{% trans "Branch is stale and can no longer be synced" %}">
+                  <i class="mdi mdi-alert-circle"></i>
+                </span>
+              {% endif %}
+              <div class="small text-muted">{{ object.synced_time|timesince }} {% trans "ago" %}</div>
+            </td>
           </tr>
           <tr>
             <th scope="row">{% trans "Last activity" %}</th>
-            <td>{{ latest_change.time|isodatetime|placeholder }}</td>
+            <td>
+              {{ latest_change.time|isodatetime|placeholder }}
+              {% if latest_change %}
+                <div class="small text-muted">{{ latest_change.time|timesince }} {% trans "ago" %}</div>
+              {% endif %}
+            </td>
           </tr>
           <tr>
             <th scope="row">{% trans "Conflicts" %}</th>

--- a/netbox_branching/templates/netbox_branching/buttons/branch_sync.html
+++ b/netbox_branching/templates/netbox_branching/buttons/branch_sync.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% if perms.netbox_branching.sync_branch %}
+{% if perms.netbox_branching.sync_branch and not branch.is_stale %}
   <a href="{% url 'plugins:netbox_branching:branch_sync' pk=branch.pk %}" class="btn btn-primary">
     <i class="mdi mdi-sync"></i> {% trans "Sync" %}
   </a>


### PR DESCRIPTION
### Fixes: #209

- Add the `is_stale` property on the Branch model
- Flag stale branches in the UI
- `sync()` now fails for stale branches
