### PR TITLE
Append dropdown-menu-end to drop down

### DIFF
--- a/netbox_branching/templates/netbox_branching/inc/branch_selector.html
+++ b/netbox_branching/templates/netbox_branching/inc/branch_selector.html
@@ -4,7 +4,7 @@
     <i class="mdi mdi-source-branch"></i>
     {{ active_branch|default:"Main" }}
   </button>
-  <div class="dropdown-menu">
+  <div class="dropdown-menu dropdown-menu-end">
     <a class="dropdown-item d-flex justify-content-between" href="?_branch=">
       Main {% if not active_branch %}<span class="badge bg-green ms-auto"></span>{% endif %}
     </a>


### PR DESCRIPTION
Fixes #222 - UX Error with long branch names go off screen

Added  `dropdown-menu-end` to the menu via dev tools to validate the change
