### PR TITLE
Fixes #225: Branch status field should not be required in REST API serializer

### DIFF
--- a/netbox_branching/api/serializers.py
+++ b/netbox_branching/api/serializers.py
@@ -31,7 +31,8 @@ class BranchSerializer(NetBoxModelSerializer):
         read_only=True
     )
     status = ChoiceField(
-        choices=BranchStatusChoices
+        choices=BranchStatusChoices,
+        required=False
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #225

Mark the `status` field as not required in BranchSerializer