### PR TITLE
Fixes #179: Avoid nullifying object representation when updating a ChangeDiff

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -159,7 +159,8 @@ class ChangeDiff(models.Model):
 
     def save(self, *args, **kwargs):
         self._update_conflicts()
-        self.object_repr = str(self.object)
+        if self.object:
+            self.object_repr = str(self.object)
 
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
### Fixes: #179

Update the `object_repr` value for a ChangeDiff only if the object is available. (Thanks to @cruse1977 for the heads up!)