### PR TITLE
Fixes #169: Replicate the global search table for each branch

### DIFF
--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -14,6 +14,7 @@ QUERY_PARAM = '_branch'
 # must be replicated for each branch to ensure proper functionality
 INCLUDE_MODELS = (
     'dcim.cablepath',
+    'extras.cachedvalue',
 )
 
 # Models for which branching support is explicitly disabled


### PR DESCRIPTION
### Fixes: #169

- Replicate the global search table for each branch
- Modifications to objects performed within a branch are reflected in the branch's local search table
- Searching with a branch active queries its local copy of the search table