### PR TITLE
Fixes #243: Defer MPTT recalculation until all changes have been applied

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -56,10 +56,6 @@ class ObjectChange(ObjectChange_):
             except model.DoesNotExist:
                 logger.debug(f'{model._meta.verbose_name} ID {self.changed_object_id} already deleted; skipping')
 
-        # Rebuild the MPTT tree where applicable
-        if issubclass(model, MPTTModel):
-            model.objects.rebuild()
-
     apply.alters_data = True
 
     def undo(self, using=DEFAULT_DB_ALIAS, logger=None):
@@ -90,10 +86,6 @@ class ObjectChange(ObjectChange_):
             logger.debug(f'Restoring {model._meta.verbose_name} {instance}')
             instance.object.full_clean()
             instance.save(using=using)
-
-        # Rebuild the MPTT tree where applicable
-        if issubclass(model, MPTTModel):
-            model.objects.rebuild()
 
     undo.alters_data = True
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -5,13 +5,12 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.postgres.fields import ArrayField
 from django.db import DEFAULT_DB_ALIAS, models
 from django.utils.translation import gettext_lazy as _
-from mptt.models import MPTTModel
 
 from core.choices import ObjectChangeActionChoices
 from core.models import ObjectChange as ObjectChange_
+from netbox_branching.utilities import update_object
 from utilities.querysets import RestrictedQuerySet
 from utilities.serialization import deserialize_object
-from netbox_branching.utilities import update_object
 
 __all__ = (
     'AppliedChange',


### PR DESCRIPTION
### Fixes: #243

- Record changed models and call `model.objects.rebuild()` under a common `_cleanup()` method on Branch
- Remove the calls to `model.objects.rebuild()` from the ObjectChange proxy model