### PR TITLE
Closes #251: Preserve SQL index names when provisioning a branch

### DIFF
--- a/netbox_branching/migrations/0003_rename_indexes.py
+++ b/netbox_branching/migrations/0003_rename_indexes.py
@@ -1,0 +1,82 @@
+from collections import namedtuple
+
+from django.db import connection, migrations
+
+from netbox.plugins import get_plugin_config
+from netbox_branching.choices import BranchStatusChoices
+from netbox_branching.utilities import get_sql_results
+
+MAIN_SCHEMA = 'public'
+
+# Indexes to ignore as they are removed in a NetBox v4.3 migration
+SKIP = (
+    'dcim_cabletermination_termination_type_id_termination_id_idx',     # Removed in dcim.0207_remove_redundant_indexes
+    'vpn_l2vpntermination_assigned_object_type_id_assigned_objec_idx',  # Removed in vpn.0009_remove_redundant_indexes
+    'vpn_tunneltermination_termination_type_id_termination_id_idx',     # Removed in vpn.0009_remove_redundant_indexes
+)
+
+
+def rename_indexes(apps, schema_editor):
+    """
+    Rename all indexes within each branch to match the main schema.
+    """
+    Branch = apps.get_model('netbox_branching', 'Branch')
+    schema_prefix = get_plugin_config('netbox_branching', 'schema_prefix')
+
+    with connection.cursor() as cursor:
+
+        for branch in Branch.objects.filter(status=BranchStatusChoices.READY):
+            print(f'\n    Renaming indexes for branch {branch.name} ({branch.schema_id})...', end='')
+            schema_name = f'{schema_prefix}{branch.schema_id}'
+
+            # Fetch all SQL indexes from the branch schema
+            cursor.execute(
+                f"SELECT tablename, indexname, indexdef FROM pg_indexes WHERE schemaname = '{schema_name}'"
+            )
+            branch_indexes = get_sql_results(cursor)
+
+            for branch_index in branch_indexes:
+
+                # Skip index if applicable
+                if branch_index.indexname in SKIP:
+                    continue
+
+                # Find the matching index in main based on its table & definition
+                definition = branch_index.indexdef.split(' USING ', maxsplit=1)[1]
+                cursor.execute(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE schemaname=%s "
+                    "AND tablename=%s "
+                    "AND indexdef LIKE %s",
+                    [MAIN_SCHEMA, branch_index.tablename, f'% {definition}']
+                )
+                if not (result := cursor.fetchone()):
+                    print(f"{branch_index.indexname}: No matching index found!")
+                    print(sql)
+                    continue
+                new_name = result[0]
+
+                # Rename the branch schema index (if needed)
+                if new_name != branch_index.indexname:
+                    sql = f"ALTER INDEX {schema_name}.{branch_index.indexname} RENAME TO {new_name}"
+                    try:
+                        cursor.execute(sql)
+                    except Exception as e:
+                        print(sql)
+                        raise e
+
+    print('\n ', end='')  # Padding for final "OK"
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_branching', '0002_branch_schema_id_unique'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=rename_indexes,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox_branching/migrations/0003_rename_indexes.py
+++ b/netbox_branching/migrations/0003_rename_indexes.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 from django.db import connection, migrations
 
 from netbox.plugins import get_plugin_config
@@ -52,7 +50,6 @@ def rename_indexes(apps, schema_editor):
                 )
                 if not (result := cursor.fetchone()):
                     print(f"{branch_index.indexname}: No matching index found!")
-                    print(sql)
                     continue
                 new_name = result[0]
 

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -573,10 +573,7 @@ class Branch(JobsMixin, PrimaryModel):
                     # Find the matching index in main based on its table & definition
                     definition = index.indexdef.split(' USING ', maxsplit=1)[1]
                     cursor.execute(
-                        "SELECT indexname FROM pg_indexes "
-                        "WHERE schemaname=%s "
-                        "AND tablename=%s "
-                        "AND indexdef LIKE %s",
+                        "SELECT indexname FROM pg_indexes WHERE schemaname=%s AND tablename=%s AND indexdef LIKE %s",
                         [MAIN_SCHEMA, index.tablename, f'% {definition}']
                     )
                     if result := cursor.fetchone():

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 
@@ -25,6 +25,7 @@ __all__ = (
     'deactivate_branch',
     'get_active_branch',
     'get_branchable_object_types',
+    'get_sql_results',
     'get_tables_to_replicate',
     'is_api_request',
     'record_applied_change',
@@ -251,6 +252,13 @@ def get_active_branch(request):
     # Branch set by cookie
     elif schema_id := request.COOKIES.get(COOKIE_NAME):
         return Branch.objects.filter(schema_id=schema_id, status=BranchStatusChoices.READY).first()
+
+
+def get_sql_results(cursor):
+    Result = namedtuple("Result", [col[0] for col in cursor.description])
+    return [
+        Result(*row) for row in cursor.fetchall()
+    ]
 
 
 @register_request_processor

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -255,6 +255,9 @@ def get_active_branch(request):
 
 
 def get_sql_results(cursor):
+    """
+    Return the results of the most recent SQL query as a list of named tuples.
+    """
     Result = namedtuple("Result", [col[0] for col in cursor.description])
     return [
         Result(*row) for row in cursor.fetchall()


### PR DESCRIPTION
### Closes: #251

- Introduce the `get_sql_results()` utility function
- Introduce a migration to automatically rename the indexes of all open branches
- Extend the `provision()` method on the Branch model to automatically rename indexes after replicating the necessary tables for a branch