### PR TITLE
Closes #181: Introduce a configuration parameter to define the default schema name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,14 @@ exempt_models = (
 
 ---
 
+## `main_schema`
+
+Default: `"public"`
+
+The name of the main (primary) PostgreSQL schema. (Use the `\dn` command in the PostgreSQL CLI to list all schemas.)
+
+---
+
 ## `max_working_branches`
 
 Default: None
@@ -46,7 +54,7 @@ The maximum total number of branches that can exist simultaneously, including me
 
 ## `schema_prefix`
 
-Default: `branch_`
+Default: `"branch_"`
 
 The string to prefix to the unique branch ID when provisioning the PostgreSQL schema for a branch. Per [the PostgreSQL documentation](https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), this string must begin with a letter or underscore.
 

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -28,6 +28,9 @@ class AppConfig(PluginConfig):
         # Models from other plugins which should be excluded from branching support
         'exempt_models': [],
 
+        # The name of the main schema
+        'main_schema': 'public',
+
         # This string is prefixed to the name of each new branch schema during provisioning
         'schema_prefix': 'branch_',
 

--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -1,6 +1,3 @@
-# Name of the main (non-branch) PostgreSQL schema
-MAIN_SCHEMA = 'public'
-
 # HTTP cookie
 COOKIE_NAME = 'active_branch'
 

--- a/netbox_branching/database.py
+++ b/netbox_branching/database.py
@@ -37,5 +37,5 @@ class BranchAwareRouter:
         return self._get_db(model, **hints)
 
     def allow_relation(self, obj1, obj2, **hints):
-        # Permit relations from the branch schema to the main (public) schema
+        # Permit relations from the branch schema to the main schema
         return True

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -6,8 +6,8 @@ from django.db import connection
 from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
 
+from netbox.plugins import get_plugin_config
 from netbox_branching.choices import BranchStatusChoices
-from netbox_branching.constants import MAIN_SCHEMA
 from netbox_branching.models import Branch
 from netbox_branching.utilities import get_tables_to_replicate
 from .utils import fetchall, fetchone
@@ -21,6 +21,7 @@ class BranchTestCase(TransactionTestCase):
         branch.save(provision=False)
         branch.provision(user=None)
 
+        main_schema = get_plugin_config('netbox_branching', 'main_schema')
         tables_to_replicate = get_tables_to_replicate()
 
         with connection.cursor() as cursor:
@@ -44,7 +45,7 @@ class BranchTestCase(TransactionTestCase):
 
             # Check that object counts match the main schema for each table
             for table_name in tables_to_replicate:
-                cursor.execute(f"SELECT COUNT(id) FROM {MAIN_SCHEMA}.{table_name}")
+                cursor.execute(f"SELECT COUNT(id) FROM {main_schema}.{table_name}")
                 main_count = fetchone(cursor).count
                 cursor.execute(f"SELECT COUNT(id) FROM {branch.schema_name}.{table_name}")
                 branch_count = fetchone(cursor).count


### PR DESCRIPTION
### Fixes: #181

- Introduce the `main_schema` configuration parameter
- Replace all references to the `MAIN_SCHEMA` constant and literal string `"public"`
- Set `main_schema` as a cached property on DynamicSchemaDict