### PR TITLE
Release v0.5.5

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.5.5
+
+### Bug Fixes
+
+* [#242](https://github.com/netboxlabs/netbox-branching/issues/242) - Use RestrictedQuerySet for BranchEvent objects
+* [#243](https://github.com/netboxlabs/netbox-branching/issues/243) - Defer MPTT recalculation until all changes have been applied
+* [#251](https://github.com/netboxlabs/netbox-branching/issues/251) - Preserve SQL index names when provisioning a branch
+
+---
+
 ## v0.5.4
 
 ### Bug Fixes

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -9,7 +9,7 @@ class AppConfig(PluginConfig):
     name = 'netbox_branching'
     verbose_name = 'NetBox Branching'
     description = 'A git-like branching implementation for NetBox'
-    version = '0.5.4'
+    version = '0.5.5'
     base_url = 'branching'
     min_version = '4.1.9'
     middleware = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-netbox-branching"
-version = "0.5.4"
+version = "0.5.5"
 description = "A git-like branching implementation for NetBox"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Bug Fixes

* [#242](https://github.com/netboxlabs/netbox-branching/issues/242) - Use RestrictedQuerySet for BranchEvent objects
* [#243](https://github.com/netboxlabs/netbox-branching/issues/243) - Defer MPTT recalculation until all changes have been applied
* [#251](https://github.com/netboxlabs/netbox-branching/issues/251) - Preserve SQL index names when provisioning a branch