### PR TITLE
Fixes #260: Ignore duplicate SQL indexes when provisioning a branch

### DIFF
--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -35,3 +35,12 @@ EXEMPT_MODELS = (
     'netbox_branching.*',
     'netbox_changes.*',
 )
+
+# Indexes to ignore as they are removed in a NetBox v4.3 migration, but might be present
+# in earlier NetBox releases.
+# TODO: Remove in v0.6.0
+SKIP_INDEXES = (
+    'dcim_cabletermination_termination_type_id_termination_id_idx',     # Removed in dcim.0207_remove_redundant_indexes
+    'vpn_l2vpntermination_assigned_object_type_id_assigned_objec_idx',  # Removed in vpn.0009_remove_redundant_indexes
+    'vpn_tunneltermination_termination_type_id_termination_id_idx',     # Removed in vpn.0009_remove_redundant_indexes
+)


### PR DESCRIPTION
### Fixes: #260

Ignore SQL indexes known to be redundant on NetBox v4.2 and earlier when provisioning a branch. (These indexes are removed in NetBox v4.3.0.)
