### PR TITLE
Release v0.5.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## v0.5.6
+
+### Enhancements
+
+* [#262](https://github.com/netboxlabs/netbox-branching/issues/262) - Copy migrations table when provisioning a branch
+
+### Bug Fixes
+
+* [#256](https://github.com/netboxlabs/netbox-branching/issues/256) - Fix "changes ahead" count on branches pending provisioning
+* [#260](https://github.com/netboxlabs/netbox-branching/issues/260) - Ignore duplicate SQL indexes when provisioning a branch
+* [#275](https://github.com/netboxlabs/netbox-branching/issues/275) - Set `sync_time` on branch during initial provisioning
+
+---
+
 ## v0.5.5
 
 ### Bug Fixes

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -9,7 +9,7 @@ class AppConfig(PluginConfig):
     name = 'netbox_branching'
     verbose_name = 'NetBox Branching'
     description = 'A git-like branching implementation for NetBox'
-    version = '0.5.5'
+    version = '0.5.6'
     base_url = 'branching'
     min_version = '4.1.9'
     middleware = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-netbox-branching"
-version = "0.5.5"
+version = "0.5.6"
 description = "A git-like branching implementation for NetBox"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Enhancements

* [#262](https://github.com/netboxlabs/netbox-branching/issues/262) - Copy migrations table when provisioning a branch

### Bug Fixes

* [#256](https://github.com/netboxlabs/netbox-branching/issues/256) - Fix "changes ahead" count on branches pending provisioning
* [#260](https://github.com/netboxlabs/netbox-branching/issues/260) - Ignore duplicate SQL indexes when provisioning a branch
* [#275](https://github.com/netboxlabs/netbox-branching/issues/275) - Set `sync_time` on branch during initial provisioning
