### PR TITLE
136 fix branch reversion

### DIFF
--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -453,7 +453,10 @@ class Branch(JobsMixin, PrimaryModel):
 
         except Exception as e:
             if err_message := str(e):
+                import traceback
                 logger.error(err_message)
+                print(e)
+                print(traceback.format_exc())
             # Disconnect signal receiver & restore original branch status
             post_save.disconnect(handler, sender=ObjectChange_)
             Branch.objects.filter(pk=self.pk).update(status=BranchStatusChoices.MERGED)

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -455,8 +455,6 @@ class Branch(JobsMixin, PrimaryModel):
             if err_message := str(e):
                 import traceback
                 logger.error(err_message)
-                print(e)
-                print(traceback.format_exc())
             # Disconnect signal receiver & restore original branch status
             post_save.disconnect(handler, sender=ObjectChange_)
             Branch.objects.filter(pk=self.pk).update(status=BranchStatusChoices.MERGED)

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -453,7 +453,6 @@ class Branch(JobsMixin, PrimaryModel):
 
         except Exception as e:
             if err_message := str(e):
-                import traceback
                 logger.error(err_message)
             # Disconnect signal receiver & restore original branch status
             post_save.disconnect(handler, sender=ObjectChange_)

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -81,9 +81,19 @@ class ObjectChange(ObjectChange_):
 
         # Restoring a deleted object
         elif self.action == ObjectChangeActionChoices.ACTION_DELETE:
-            instance = deserialize_object(model, self.prechange_data, pk=self.changed_object_id)
+            deserialized = deserialize_object(model, self.prechange_data_clean, pk=self.changed_object_id)
+            instance = deserialized.object
             logger.debug(f'Restoring {model._meta.verbose_name} {instance}')
-            instance.object.full_clean()
+            
+            # Restore GenericForeignKey fields
+            for field in instance._meta.private_fields:
+                if isinstance(field, GenericForeignKey):
+                    ct_field = getattr(instance, field.ct_field)
+                    fk_field = getattr(instance, field.fk_field)
+                    if ct_field and fk_field:
+                        setattr(instance, field.name, ct_field.get_object_for_this_type(pk=fk_field))
+            
+            instance.full_clean()
             instance.save(using=using)
 
     undo.alters_data = True

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -84,7 +84,7 @@ class ObjectChange(ObjectChange_):
             deserialized = deserialize_object(model, self.prechange_data_clean, pk=self.changed_object_id)
             instance = deserialized.object
             logger.debug(f'Restoring {model._meta.verbose_name} {instance}')
-            
+
             # Restore GenericForeignKey fields
             for field in instance._meta.private_fields:
                 if isinstance(field, GenericForeignKey):
@@ -92,7 +92,7 @@ class ObjectChange(ObjectChange_):
                     fk_field = getattr(instance, field.fk_field)
                     if ct_field and fk_field:
                         setattr(instance, field.name, ct_field.get_object_for_this_type(pk=fk_field))
-            
+
             instance.full_clean()
             instance.save(using=using)
 


### PR DESCRIPTION
### Fixes: #136 

Note: This requires the NetBox change https://github.com/netbox-community/netbox/issues/19680 to work correctly.

This was caused by several issues:

1. In NetBox the ordering of ChangeLog items when there were GenericRelations between them was out-of-order.  This is fixed in the NetBox PR above.
2. Following this - the `deserialize_object` was using `self.prechange_data`, but this was picking up internal fields like `_path` on cabled objects, changed to use `self.prechange_data_clean` to remove these fields.
3. Also - the clean method in Cable uses the GenericForeign key reference, the deserializer sets the object_id and content_type but the actual content_object was None.  This goes through and fixes these back up.