### PR TITLE
Fixes #299: Avoid exception due to invalid content type when provisioning a branch

### DIFF
--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -135,6 +135,7 @@ def get_tables_to_replicate():
 
     branch_aware_models = [
         ot.model_class() for ot in get_branchable_object_types()
+        if ot.model_class() is not None
     ]
     for model in branch_aware_models:
 


### PR DESCRIPTION
### Fixes: #299

Include only object types for which a valid model class is registered when determining which database tables to replicate.