### PR TITLE
Fixes #308: Utilize new model feature registration in NetBox v4.4

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -3,8 +3,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 from netbox.plugins import PluginConfig, get_plugin_config
+from netbox.utils import register_model_feature
 from .constants import BRANCH_ACTIONS
-from .utilities import register_models
+from .utilities import supports_branching
 
 
 class AppConfig(PluginConfig):
@@ -57,8 +58,8 @@ class AppConfig(PluginConfig):
                 "netbox_branching: DATABASE_ROUTERS must contain 'netbox_branching.database.BranchAwareRouter'."
             )
 
-        # Register models which support branching
-        register_models()
+        # Register the "branching" model feature
+        register_model_feature('branching', supports_branching)
 
         # Validate & register configured branch action validators
         for action in BRANCH_ACTIONS:

--- a/netbox_branching/tests/test_config.py
+++ b/netbox_branching/tests/test_config.py
@@ -1,8 +1,8 @@
 from django.test import TransactionTestCase, override_settings
 
-from netbox.registry import registry
+from ipam.models import Prefix
 from netbox_branching.models import Branch
-from netbox_branching.utilities import register_models
+from netbox_branching.utilities import supports_branching
 
 
 class ConfigTestCase(TransactionTestCase):
@@ -14,8 +14,7 @@ class ConfigTestCase(TransactionTestCase):
         }
     })
     def test_exempt_models(self):
-        register_models()
-        self.assertNotIn('prefix', registry['model_features']['branching']['ipam'])
+        self.assertFalse(supports_branching(Prefix))
 
     @override_settings(PLUGINS_CONFIG={
         'netbox_branching': {


### PR DESCRIPTION
### Fixes: #308

- Remove legacy `register_models()` function; feature registration is now handled by NetBox natively
- Introduce `supports_branching()` to evaluate whether a given model support branching
- Register the `"branching"` feature using NetBox's `register_model_feature()`

**Note:** This needs to be tested against the `20137-objecttype-get_for_model` branch of NetBox until PR netbox-community/netbox#20138 is merged.