### PR TITLE
Fixes #309: Ensure ObjectChange migrations are applied for branches

### DIFF
--- a/netbox_branching/database.py
+++ b/netbox_branching/database.py
@@ -64,6 +64,10 @@ class BranchAwareRouter:
 
         # Disallow migrations for models which don't support branching
         if model_name:
+            # Permit migrations for the ObjectChange model
+            if app_label == 'core' and model_name == 'objectchange':
+                return True
+
             from core.models import ObjectType
             if not ObjectType.objects.using(DEFAULT_DB_ALIAS).filter(
                     app_label=app_label,

--- a/netbox_branching/views.py
+++ b/netbox_branching/views.py
@@ -50,11 +50,12 @@ class BranchView(generic.ObjectView):
                     for ct, count in qs.filter(action=ObjectChangeActionChoices.ACTION_DELETE)
                 },
             }
+            latest_change = instance.get_changes().order_by('time').last()
+            last_job = instance.jobs.order_by('created').last()
         else:
             stats = {}
-
-        latest_change = instance.get_changes().order_by('time').last()
-        last_job = instance.jobs.order_by('created').last()
+            latest_change = None
+            last_job = None
 
         return {
             'stats': stats,


### PR DESCRIPTION
### Fixes: #309

- Make an exception for the ObjectChange model under `allow_migrate()` in the database router
- Show the most recent change & job only for ready/merged branches (avoids raising an exception with unapplied migrations)
