### PR TITLE
Fixes #325: Enforce maximum NetBox version for v0.6

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -14,6 +14,7 @@ class AppConfig(PluginConfig):
     version = '0.6.1'
     base_url = 'branching'
     min_version = '4.3.2'
+    max_version = '4.3.99'
     middleware = [
         'netbox_branching.middleware.BranchMiddleware'
     ]


### PR DESCRIPTION
### Fixes: #325

Enforce a maximum NetBox version of 4.3.x for plugin version 0.6.x.