### PR TITLE
Release v0.6.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.6.2
+
+### Bug Fixes
+
+* [#298](https://github.com/netboxlabs/netbox-branching/issues/298) - Fix change diff creation for many-to-many fields
+* [#321](https://github.com/netboxlabs/netbox-branching/issues/321) - Prevent tag object type reassignments from leaking outside a branch
+* [#325](https://github.com/netboxlabs/netbox-branching/issues/325) - Enforce a maximum NetBox version of 4.3
+
+---
+
 ## v0.6.1
 
 ### Bug Fixes

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -11,7 +11,7 @@ class AppConfig(PluginConfig):
     name = 'netbox_branching'
     verbose_name = 'NetBox Branching'
     description = 'A git-like branching implementation for NetBox'
-    version = '0.6.1'
+    version = '0.6.2'
     base_url = 'branching'
     min_version = '4.3.2'
     max_version = '4.3.99'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-netbox-branching"
-version = "0.6.1"
+version = "0.6.2"
 description = "A git-like branching implementation for NetBox"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Bug Fixes

* [#298](https://github.com/netboxlabs/netbox-branching/issues/298) - Fix change diff creation for many-to-many fields
* [#321](https://github.com/netboxlabs/netbox-branching/issues/321) - Prevent tag object type reassignments from leaking outside a branch
* [#325](https://github.com/netboxlabs/netbox-branching/issues/325) - Enforce a maximum NetBox version of 4.3
