### PR TITLE
Fixes #317: Prevent garbage collection of branch event signal receive…

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -129,11 +129,12 @@ def handle_branch_event(event_type, branch, user=None, **kwargs):
     )
 
 
-signals.post_provision.connect(partial(handle_branch_event, event_type=BRANCH_PROVISIONED))
-signals.post_deprovision.connect(partial(handle_branch_event, event_type=BRANCH_DEPROVISIONED))
-signals.post_sync.connect(partial(handle_branch_event, event_type=BRANCH_SYNCED))
-signals.post_merge.connect(partial(handle_branch_event, event_type=BRANCH_MERGED))
-signals.post_revert.connect(partial(handle_branch_event, event_type=BRANCH_REVERTED))
+# Connect signals with weak=False to prevent garbage collection of partial objects
+signals.post_provision.connect(partial(handle_branch_event, event_type=BRANCH_PROVISIONED), weak=False)
+signals.post_deprovision.connect(partial(handle_branch_event, event_type=BRANCH_DEPROVISIONED), weak=False)
+signals.post_sync.connect(partial(handle_branch_event, event_type=BRANCH_SYNCED), weak=False)
+signals.post_merge.connect(partial(handle_branch_event, event_type=BRANCH_MERGED), weak=False)
+signals.post_revert.connect(partial(handle_branch_event, event_type=BRANCH_REVERTED), weak=False)
 
 
 @receiver(pre_delete, sender=Branch)


### PR DESCRIPTION
…rs Event rules were not triggering for branch operations because signal receivers using functools.partial were being garbage collected.

### Fixes: #317

The signal connections created inline partial objects without any module-level references.
Ref: https://docs.djangoproject.com/en/5.2/topics/signals/

I believe the temporary partial object goes out of scope, so refcount = 0, and therefore CPython immediately deallocates the object.