### PR TITLE
Fixes #349: Calculate conflicts for ChangeDiff only when both original and current data exist

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -191,6 +191,9 @@ class ChangeDiff(models.Model):
         """
         Record any conflicting changes between the modified and current object data.
         """
+        if self.original is None or self.current is None:
+            # Both the original and current states must be available to compare
+            return
         conflicts = None
         if self.action == ObjectChangeActionChoices.ACTION_UPDATE:
             conflicts = [


### PR DESCRIPTION
### Fixes: #349

`_update_conflicts()` should no-op if either the original or current data is missing for comparison.
