### PR TITLE
Release v0.7.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## v0.7.2
+
+### Enhancements
+
+* [#342](https://github.com/netboxlabs/netbox-branching/issues/342) - Display warning when attempting to modify an object that has been deleted in main
+* [#347](https://github.com/netboxlabs/netbox-branching/issues/347) - Include ObjectChange ID in log messages when applying/undoing changes
+
+### Bug Fixes
+
+* [#311](https://github.com/netboxlabs/netbox-branching/issues/311) - Fix merge failure when image attachments are created and subsequently deleted
+* [#317](https://github.com/netboxlabs/netbox-branching/issues/317) - Fix event rules not triggering for branch events
+* [#349](https://github.com/netboxlabs/netbox-branching/issues/349) - Fix exception when removing a device from a virtual chassis with a branch active
+
+---
+
 ## v0.7.1
 
 ### Bug Fixes

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -12,7 +12,7 @@ class AppConfig(PluginConfig):
     name = 'netbox_branching'
     verbose_name = 'NetBox Branching'
     description = 'A git-like branching implementation for NetBox'
-    version = '0.7.1'
+    version = '0.7.2'
     base_url = 'branching'
     min_version = '4.4.1'
     max_version = '4.4.99'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-netbox-branching"
-version = "0.7.1"
+version = "0.7.2"
 description = "A git-like branching implementation for NetBox"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Enhancements

* [#342](https://github.com/netboxlabs/netbox-branching/issues/342) - Display warning when attempting to modify an object that has been deleted in main
* [#347](https://github.com/netboxlabs/netbox-branching/issues/347) - Include ObjectChange ID in log messages when applying/undoing changes

## Bug Fixes

* [#311](https://github.com/netboxlabs/netbox-branching/issues/311) - Fix merge failure when image attachments are created and subsequently deleted
* [#317](https://github.com/netboxlabs/netbox-branching/issues/317) - Fix event rules not triggering for branch events
* [#349](https://github.com/netboxlabs/netbox-branching/issues/349) - Fix exception when removing a device from a virtual chassis with a branch active