### PR TITLE
Fixes #354: Route TaggedItem queries to branch schema

### DIFF
--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -21,6 +21,7 @@ QUERY_PARAM = '_branch'
 INCLUDE_MODELS = (
     'dcim.cablepath',
     'extras.cachedvalue',
+    'extras.taggeditem',  # Fix for issue #354 - tags through model
     'tenancy.contactgroupmembership',  # Fix for NetBox v4.3.0
 )
 


### PR DESCRIPTION
### Fixes: #354

Added `extras.taggeditem` to `INCLUDE_MODELS` to ensure `TaggedItem` queries are routed to the active branch schema instead of main. This fixes edit forms showing incorrect tag state when tags are added or removed in a branch.