### PR TITLE
#365 disable deleted in main check in sync

### DIFF
--- a/netbox_branching/jobs.py
+++ b/netbox_branching/jobs.py
@@ -5,6 +5,7 @@ from django.db.models.signals import m2m_changed, post_save, pre_delete
 from core.signals import handle_changed_object, handle_deleted_object
 from netbox.jobs import JobRunner
 from utilities.exceptions import AbortTransaction
+from .signal_receivers import validate_object_deletion_in_branch
 from .utilities import ListHandler
 
 __all__ = (
@@ -58,6 +59,7 @@ class SyncBranchJob(JobRunner):
         post_save.disconnect(handle_changed_object)
         m2m_changed.disconnect(handle_changed_object)
         pre_delete.disconnect(handle_deleted_object)
+        pre_delete.disconnect(validate_object_deletion_in_branch)
 
     def _reconnect_signal_receivers(self):
         """
@@ -66,6 +68,7 @@ class SyncBranchJob(JobRunner):
         post_save.connect(handle_changed_object)
         m2m_changed.connect(handle_changed_object)
         pre_delete.connect(handle_deleted_object)
+        pre_delete.connect(validate_object_deletion_in_branch)
 
     def run(self, commit=True, *args, **kwargs):
         # Initialize logging


### PR DESCRIPTION
### Fixes: #365 

Disables the pre_delete signal handler for the check on objects being deleted in main branch when doing a sync.
