### PR TITLE
Fixes #371: Ignore module import errors when discovering object migrators

### DIFF
--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -314,7 +314,12 @@ class Branch(JobsMixin, PrimaryModel):
         migrators = defaultdict(list)
         for migration in self.applied_migrations:
             app_label, name = migration.split('.')
-            module = importlib.import_module(f'{app_label}.migrations.{name}')
+            try:
+                module = importlib.import_module(f'{app_label}.migrations.{name}')
+            except ModuleNotFoundError:
+                logger = logging.getLogger('netbox_branching.branch')
+                logger.warning(f"Failed to load module for migration {migration}; skipping.")
+                continue
             for object_type, migrator in getattr(module, 'objectchange_migrators', {}).items():
                 migrators[object_type].append(migrator)
         return migrators


### PR DESCRIPTION
### Fixes: #371

This specifically addresses a known issue with `sorl-thumbnail`, but applies a general workaround.