### PR TITLE
Fixes #388: Fix deletion of M2M assignments created within a branch

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -18,6 +18,7 @@ from netbox_branching import signals
 from utilities.exceptions import AbortRequest
 from utilities.serialization import serialize_object
 from .choices import BranchStatusChoices
+from .constants import INCLUDE_MODELS
 from .contextvars import active_branch
 from .events import *
 from .models import Branch, ChangeDiff
@@ -48,6 +49,12 @@ def check_object_accessible_in_branch(branch, model, object_id):
     Returns:
         True if the object is accessible (exists in main or was created in branch), False otherwise
     """
+    # Exempt models listed in INCLUDE_MODELS. These are replicated when a new branch is provisioned but are not
+    # managed directly.
+    if f'{model._meta.app_label}.{model._meta.model_name}' in INCLUDE_MODELS:
+        return True
+
+    # Check whether the object exists in main
     with deactivate_branch():
         try:
             model.objects.get(pk=object_id)


### PR DESCRIPTION
### Fixes: #388

`check_object_accessible_in_branch()` should always return True for models in `INCLUDE_MODELS`, which support branches but are not tracked via ChangeDiffs.