### PR TITLE
Fixes #408: Ensure that ChangeDiff has the newest changed object ref

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -145,6 +145,7 @@ def record_change_diff(instance, **kwargs):
         # Updating the existing ChangeDiff
         if diff := ChangeDiff.objects.filter(object_type=content_type, object_id=object_id, branch=branch).first():
             logger.debug(f"Updating branch change diff for change to {instance.changed_object}")
+            diff.object = instance.changed_object
             diff.last_updated = timezone.now()
             if diff.action != ObjectChangeActionChoices.ACTION_CREATE:
                 diff.action = instance.action


### PR DESCRIPTION
### Fixes: #408

When an object is modified in a branch after initial creation, the `ChangeDiff` record is updated with new data, but the `object_repr` field was not being refreshed. This caused change requests in NetBox Change Management to display stale object data (e.g., showing "site_1" even after renaming to "site_2").