### PR TITLE
Fixes #428: Handle None values in ChangeDiff diff properties

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -270,10 +270,12 @@ class ChangeDiff(models.Model):
         """
         Return a key-value mapping of all attributes which have been modified within the branch.
         """
-        return {
-            k: v for k, v in self.modified.items()
-            if k in self.altered_fields
-        }
+        if self.modified:
+            return {
+                k: v for k, v in self.modified.items()
+                if k in self.altered_fields
+            }
+        return {}
 
     @cached_property
     def current_diff(self):

--- a/netbox_branching/tests/test_changediff.py
+++ b/netbox_branching/tests/test_changediff.py
@@ -2,23 +2,17 @@ from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
 
 from core.choices import ObjectChangeActionChoices
+from dcim.models import Site
 from netbox_branching.models import Branch, ChangeDiff
 
 
 class ChangeDiffTestCase(TestCase):
-    """
-    Test cases for ChangeDiff model diff properties.
-    """
 
     def setUp(self):
         self.branch = Branch.objects.create(name='Test Branch')
-        self.content_type = ContentType.objects.get_for_model(Branch)
+        self.content_type = ContentType.objects.get_for_model(Site)
 
-    def test_diff_properties_with_create_action(self):
-        """
-        Test that diff properties handle CREATE action where original=None and current=None.
-        Fixes issue #428.
-        """
+    def test_create_action_none_handling(self):
         change_diff = ChangeDiff(
             branch=self.branch,
             object_type=self.content_type,
@@ -26,11 +20,51 @@ class ChangeDiffTestCase(TestCase):
             object_repr='Test CREATE',
             action=ObjectChangeActionChoices.ACTION_CREATE,
             original=None,
-            modified={'id': 1, 'name': 'new_object'},
+            modified={'id': 1, 'name': 'new_object', 'status': 'active'},
             current=None,
         )
 
-        # These should not raise AttributeError
+        self.assertEqual(change_diff.altered_in_modified, set())
+        self.assertEqual(change_diff.altered_in_current, set())
+        self.assertEqual(change_diff.altered_fields, [])
         self.assertEqual(change_diff.original_diff, {})
-        self.assertIsInstance(change_diff.modified_diff, dict)
+        self.assertEqual(change_diff.modified_diff, {})
+        self.assertEqual(change_diff.current_diff, {})
+
+    def test_delete_action_none_handling(self):
+        change_diff = ChangeDiff(
+            branch=self.branch,
+            object_type=self.content_type,
+            object_id=2,
+            object_repr='Test DELETE',
+            action=ObjectChangeActionChoices.ACTION_DELETE,
+            original={'id': 2, 'name': 'deleted_object', 'status': 'active'},
+            modified=None,
+            current={'id': 2, 'name': 'deleted_object', 'status': 'active'},
+        )
+
+        self.assertEqual(change_diff.altered_in_modified, set())
+        self.assertEqual(change_diff.altered_in_current, set())
+        self.assertEqual(change_diff.altered_fields, [])
+        self.assertEqual(change_diff.original_diff, {})
+        self.assertEqual(change_diff.modified_diff, {})
+        self.assertEqual(change_diff.current_diff, {})
+
+    def test_update_action_current_none_handling(self):
+        change_diff = ChangeDiff(
+            branch=self.branch,
+            object_type=self.content_type,
+            object_id=3,
+            object_repr='Test UPDATE no main',
+            action=ObjectChangeActionChoices.ACTION_UPDATE,
+            original={'id': 3, 'name': 'original_name', 'status': 'active'},
+            modified={'id': 3, 'name': 'modified_name', 'status': 'active'},
+            current=None,
+        )
+
+        self.assertEqual(change_diff.altered_in_modified, {'name'})
+        self.assertEqual(change_diff.altered_in_current, set())
+        self.assertEqual(change_diff.altered_fields, ['name'])
+        self.assertEqual(change_diff.original_diff, {'name': 'original_name'})
+        self.assertEqual(change_diff.modified_diff, {'name': 'modified_name'})
         self.assertEqual(change_diff.current_diff, {})


### PR DESCRIPTION
### Fixes: #428

Fixes `AttributeError` when viewing the Diff tab for objects created or deleted in a branch.

Adds None guards to ChangeDiff properties that call `.items()` on potentially None fields:
- `original_diff` - returns `{}` when `original` is None (CREATE actions)
- `modified_diff` - returns `{}` when `modified` is None (DELETE actions)
- `current_diff` - returns `{}` when `current` is None (branch-created objects)
- `altered_in_modified` - returns `set()` when `modified` or `original` is None
- `altered_in_current` - returns `set()` when `current` or `original` is None

Scenarios fixed:
- CREATE: `original=None`, `modified={...}`, `current=None`
- DELETE: `original={...}`, `modified=None`, `current={...}`
- UPDATE on branch-created object: `original={...}`, `modified={...}`, `current=None`