### PR TITLE
#440 Add API tests for sync, merge, revert APIs

### DIFF
--- a/netbox_branching/tests/test_api.py
+++ b/netbox_branching/tests/test_api.py
@@ -28,6 +28,7 @@ class BaseAPITestCase:
         ContentType.objects.get_for_model(Branch)
 
     # TODO: Remove when dropping support for NetBox v4.4
+    @staticmethod
     def create_token(user):
         try:
             # NetBox >= 4.5


### PR DESCRIPTION
### Fixes: #440 

Extends the API tests cases for sync, merge and revert which were missing.