### PR TITLE
Add new PortMapping model backing tables

### DIFF
--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -42,6 +42,8 @@ INCLUDE_MODELS = (
     'extras.cachedvalue',
     'extras.taggeditem',  # Fix for issue #354 - tags through model
     'tenancy.contactgroupmembership',  # Fix for NetBox v4.3.0
+    'dcim.portmapping',           # Fix for NetBox v4.5.x
+    'dcim.porttemplatemapping',   # Fix for NetBox v4.5.x
 )
 
 # Models for which branching support is explicitly disabled


### PR DESCRIPTION
# dcim_portmapping/dcim_porttemplatemapping not replicated into branch schemas, causing FK constraint violations

A long description for a simple issue, assuming I didn't misdiagnose things.

## Summary

Port mapping functionality was reworked in https://github.com/netbox-community/netbox/pull/20851 .

Currently with netbox-branching, `dcim_portmapping` and `dcim_porttemplatemapping` are not replicated into branch schemas. Writes to these tables while a branch is active go to the main schema instead. The FK constraint violation is a symptom of this — it surfaces when the referenced object happens to exist only in the branch schema, for example a `DeviceType` created within the branch.

## Error

```
IntegrityError: insert or update on table "dcim_porttemplatemapping"
violates foreign key constraint
"dcim_porttemplatemap_device_type_id_dede0eeb_fk_dcim_devi"
DETAIL: Key (device_type_id)=(68) is not present in table "dcim_devicetype".
```

## Root cause

`PortMappingBase` inherits from `models.Model` directly rather than `ChangeLoggedModel`:

https://github.com/netbox-community/netbox/blob/8ab752b9ad433d93860d112603eecbc79c595455/netbox/dcim/models/base.py#L13-L30

Every other template model in `device_component_templates.py` inherits from `ChangeLoggedModel`, which includes `ChangeLoggingMixin`. netbox-branching's `supports_branching()` uses that mixin, or INCLUDE_MODELS as the criterion for which models get provisioned into branch schemas:

https://github.com/netboxlabs/netbox-branching/blob/6c35cb2faa24d5317bad9136ed44dc5047f7276b/netbox_branching/utilities.py#L144-L167

Because `PortMappingBase` does not inherit `ChangeLoggingMixin`, neither `dcim.PortMapping` nor `dcim.PortTemplateMapping` pass this check. As a result, `dcim_portmapping` and `dcim_porttemplatemapping` are never provisioned into branch schemas. All writes to these tables therefore land in `public`, where branch-local objects (e.g. a `DeviceType` created within the branch) do not exist, causing the FK constraint violation.

Since I'm not familiar with the internals, it's unclear to me whether omitting `ChangeLoggedModel` from `PortMappingBase` was a deliberate design decision or an oversight (I'm leaning towards deliberate, given the increased complexity around change logging, and that this seems to be some kind of backing model, instead accessed through `FrontPortTemplate` or `RearPortTemplate`'s serializers in the UI) — these models were introduced recently and branching compatibility may simply not have been considered. The fix proposed below is the direct conclusion of following the code path, but may not be the intended solution.

## Fix

Add both models to `INCLUDE_MODELS` in `netbox_branching/constants.py`, consistent with the existing pattern for internal tables that require branch replication without change logging:

https://github.com/netboxlabs/netbox-branching/blob/6c35cb2faa24d5317bad9136ed44dc5047f7276b/netbox_branching/constants.py#L38-L40

No migration is required. Existing branch schemas will not have the tables retroactively - new branches must be created after applying this fix.