### PR TITLE
#335 Add conflict handling to API

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -174,7 +174,7 @@ Each entry in `conflicts` corresponds to a `ChangeDiff` record and includes:
 
 | Field | Description |
 |-------|-------------|
-| `id` | The `ChangeDiff` PK — used to acknowledge the conflict |
+| `id` | The `ChangeDiff` PK |
 | `object_type` | The type of the affected object (e.g. `dcim.site`) |
 | `object_id` | The PK of the affected object |
 | `object_repr` | Human-readable name of the affected object |
@@ -193,7 +193,7 @@ http://netbox:8000/api/plugins/branching/changes/6/
 
 ### Acknowledging Conflicts
 
-To proceed despite conflicts, include an `acknowledged_conflicts` list of `ChangeDiff` PKs in the request body. All conflicting PKs must be acknowledged — a partial list will still return `409` with the remaining unacknowledged conflicts.
+To proceed despite conflicts, include `"acknowledge_conflicts": true` in the request body. This signals that you have reviewed the conflicts and accept that the branch's version of the affected fields will overwrite whatever is currently in main.
 
 ```no-highlight title="Request"
 curl -X POST \
@@ -201,8 +201,8 @@ curl -X POST \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox:8000/api/plugins/branching/branches/2/sync/ \
---data '{"commit": true, "acknowledged_conflicts": [6]}'
+--data '{"commit": true, "acknowledge_conflicts": true}'
 ```
 
 !!! warning
-    Acknowledging a conflict means the branch's version of the affected fields will overwrite whatever is currently in main. Review `conflicting_data` carefully before proceeding.
+    Acknowledging conflicts means the branch's version of all conflicting fields will overwrite whatever is currently in main. Review `conflicting_data` carefully before proceeding.

--- a/netbox_branching/api/serializers.py
+++ b/netbox_branching/api/serializers.py
@@ -15,6 +15,7 @@ __all__ = (
     'BranchSerializer',
     'ChangeDiffSerializer',
     'CommitSerializer',
+    'ConflictResponseSerializer',
     'ConflictSummarySerializer',
 )
 
@@ -166,10 +167,14 @@ class ConflictSummarySerializer(serializers.ModelSerializer):
         }
 
 
+class ConflictResponseSerializer(serializers.Serializer):
+    """
+    Shape of the HTTP 409 response body returned by the sync and merge actions.
+    """
+    detail = serializers.CharField()
+    conflicts = ConflictSummarySerializer(many=True)
+
+
 class CommitSerializer(serializers.Serializer):
     commit = serializers.BooleanField(required=False)
-    acknowledged_conflicts = serializers.ListField(
-        child=serializers.IntegerField(),
-        required=False,
-        default=list,
-    )
+    acknowledge_conflicts = serializers.BooleanField(required=False, default=False)

--- a/netbox_branching/api/views.py
+++ b/netbox_branching/api/views.py
@@ -30,19 +30,20 @@ class BranchViewSet(ModelViewSet):
 
     def _check_conflicts(self, branch, serializer):
         """
-        Return a 409 response if the branch has unacknowledged conflicts, else None.
+        Return a 409 response if the branch has conflicts and they have not been
+        acknowledged, else None.
         """
-        conflicts = ChangeDiff.objects.filter(branch=branch, conflicts__isnull=False)
-        if not conflicts.exists():
+        if serializer.validated_data.get('acknowledge_conflicts', False):
             return None
-        acknowledged = set(serializer.validated_data.get('acknowledged_conflicts', []))
-        unacknowledged = conflicts.exclude(pk__in=acknowledged)
-        if not unacknowledged.exists():
+        conflicts = ChangeDiff.objects.filter(
+            branch=branch, conflicts__isnull=False
+        ).select_related('object_type')
+        if not conflicts.exists():
             return None
         return Response(
             {
                 'detail': 'All conflicts must be acknowledged before this action can proceed.',
-                'conflicts': serializers.ConflictSummarySerializer(unacknowledged, many=True).data,
+                'conflicts': serializers.ConflictSummarySerializer(conflicts, many=True).data,
             },
             status=status.HTTP_409_CONFLICT,
         )
@@ -50,7 +51,7 @@ class BranchViewSet(ModelViewSet):
     @extend_schema(
         methods=['post'],
         request=serializers.CommitSerializer(),
-        responses={200: JobSerializer(), 409: serializers.ConflictSummarySerializer(many=True)},
+        responses={200: JobSerializer(), 409: serializers.ConflictResponseSerializer()},
     )
     @action(detail=True, methods=['post'])
     def sync(self, request, pk):
@@ -82,7 +83,7 @@ class BranchViewSet(ModelViewSet):
     @extend_schema(
         methods=['post'],
         request=serializers.CommitSerializer(),
-        responses={200: JobSerializer(), 409: serializers.ConflictSummarySerializer(many=True)},
+        responses={200: JobSerializer(), 409: serializers.ConflictResponseSerializer()},
     )
     @action(detail=True, methods=['post'])
     def merge(self, request, pk):

--- a/netbox_branching/tests/test_api.py
+++ b/netbox_branching/tests/test_api.py
@@ -326,33 +326,32 @@ class BranchConflictAPITestMixin:
 
     def test_acknowledged_conflicts_proceeds(self):
         branch = self.make_branch()
-        diff = self.make_conflict(branch)
+        self.make_conflict(branch)
 
         response = self.client.post(
             self.get_url(branch.pk),
-            data=json.dumps({'commit': False, 'acknowledged_conflicts': [diff.pk]}),
+            data=json.dumps({'commit': False, 'acknowledge_conflicts': True}),
             content_type='application/json',
             **self.header
         )
 
         self.assertEqual(response.status_code, 200)
 
-    def test_partial_acknowledgement_returns_409(self):
+    def test_unacknowledged_conflicts_returns_409(self):
         branch = self.make_branch()
-        diff1 = self.make_conflict(branch, slug_suffix='-1')
-        diff2 = self.make_conflict(branch, slug_suffix='-2')
+        self.make_conflict(branch, slug_suffix='-1')
+        self.make_conflict(branch, slug_suffix='-2')
 
         response = self.client.post(
             self.get_url(branch.pk),
-            data=json.dumps({'commit': False, 'acknowledged_conflicts': [diff1.pk]}),
+            data=json.dumps({'commit': False, 'acknowledge_conflicts': False}),
             content_type='application/json',
             **self.header
         )
 
         self.assertEqual(response.status_code, 409)
         data = json.loads(response.content)
-        returned_ids = [c['id'] for c in data['conflicts']]
-        self.assertEqual(returned_ids, [diff2.pk])
+        self.assertEqual(len(data['conflicts']), 2)
 
 
 class BranchSyncAPITestCase(BranchConflictAPITestMixin, BaseBranchAPITestCase, TransactionTestCase):


### PR DESCRIPTION
### Fixes: #335 

If a branch has conflicts a sync or merge API call will return an HTTP_409 and details of the conflicts in the response:

```
      {
            "detail": "All conflicts must be acknowledged before this action can proceed.",
            "conflicts": [
                  {
                        "id": 6,
                        "object_type": "dcim.site",
                        "object_id": 31,
                        "object_repr": "s1",
                        "action": {
                              "value": "update",
                              "label": "Updated"
                        },
                        "conflicts": [
                              "tags",
                              "description"
                        ],
                        "conflicting_data": {
                              "original": {
                                    "tags": [],
                                    "description": ""
                              },
                              "branch": {
                                    "tags": [
                                          "Alpha",
                                          "Foxtrot"
                                    ],
                                    "description": "abc"
                              },
                              "main": {
                                    "tags": [
                                          "Alpha",
                                          "Charlie",
                                          "Delta"
                                    ],
                                    "description": "def"
                              }
                        },
                        "last_updated": "2026-03-24T17:07:10.442432Z"
                  }
            ]
      }
```
The Id's in conflicts are the ChangeDiff records (same as show in the UI).

To proceed despite conflicts, include `"acknowledge_conflicts": true` in the request body. This signals that you have reviewed the conflicts and accept that the branch's version of the affected fields will overwrite whatever is currently in main.

```no-highlight title="Request"
curl -X POST \
-H "Authorization: Token $TOKEN" \
-H "Content-Type: application/json" \
-H "Accept: application/json; indent=4" \
http://netbox:8000/api/plugins/branching/branches/2/sync/ \
--data '{"commit": true, "acknowledge_conflicts": true}'
```

Included a file I used to test the API - update with your API key:
[test_conflict_api.py](https://github.com/user-attachments/files/26222770/test_conflict_api.py)
