### PR TITLE
#506 - Set SAMESITE for branch cookie

### DIFF
--- a/netbox_branching/middleware.py
+++ b/netbox_branching/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
@@ -18,11 +19,29 @@ class BranchMiddleware:
     def _apply_branch_cookie(self, response, branch, branch_change):
         """
         Apply or remove the branch cookie on the given response.
+
+        Cookie attributes mirror Django's SESSION_COOKIE_* settings so the
+        branch cookie is treated consistently with the session cookie by the
+        browser (in particular, SameSite must be set explicitly — browsers
+        that don't default to Lax will otherwise drop the cookie on
+        cross-site navigation, causing branch writes to leak to main).
         """
         if branch:
-            response.set_cookie(COOKIE_NAME, branch.schema_id)
+            response.set_cookie(
+                COOKIE_NAME,
+                branch.schema_id,
+                domain=settings.SESSION_COOKIE_DOMAIN,
+                path=settings.SESSION_COOKIE_PATH,
+                secure=settings.SESSION_COOKIE_SECURE,
+                samesite=settings.SESSION_COOKIE_SAMESITE,
+            )
         elif branch_change:
-            response.delete_cookie(COOKIE_NAME)
+            response.delete_cookie(
+                COOKIE_NAME,
+                domain=settings.SESSION_COOKIE_DOMAIN,
+                path=settings.SESSION_COOKIE_PATH,
+                samesite=settings.SESSION_COOKIE_SAMESITE,
+            )
 
     def __call__(self, request):
 
@@ -41,8 +60,10 @@ class BranchMiddleware:
 
         # Set/clear the branch cookie (for non-API requests)
         if not is_api_request(request):
-            # Check if a branch is being activated/deactivated
-            branch_change = QUERY_PARAM in request.GET
+            # Check if a branch is being activated/deactivated, or if a stale
+            # cookie exists (cookie present but branch not active — e.g. branch
+            # was archived or merged since the cookie was set).
+            branch_change = QUERY_PARAM in request.GET or (COOKIE_NAME in request.COOKIES and not branch)
 
             # Redirect to dashboard if branch activation/deactivation results in 404
             if branch_change and response.status_code == 404:

--- a/netbox_branching/tests/test_request.py
+++ b/netbox_branching/tests/test_request.py
@@ -16,7 +16,13 @@ class RequestTestCase(TestCase):
         branch.status = BranchStatusChoices.READY  # Fake provisioning
         branch.save(provision=False)
 
-    @override_settings(LOGIN_REQUIRED=False)
+    @override_settings(
+        LOGIN_REQUIRED=False,
+        SESSION_COOKIE_DOMAIN='example.com',
+        SESSION_COOKIE_PATH='/custom',
+        SESSION_COOKIE_SECURE=True,
+        SESSION_COOKIE_SAMESITE='Strict',
+    )
     def test_activate_branch(self):
         branch = Branch.objects.first()
 
@@ -31,7 +37,20 @@ class RequestTestCase(TestCase):
             msg="Branch ID set in cookie is incorrect"
         )
 
-    @override_settings(LOGIN_REQUIRED=False)
+        # Cookie attributes should mirror SESSION_COOKIE_* settings
+        cookie = response.cookies[COOKIE_NAME]
+        self.assertEqual(cookie['domain'], 'example.com')
+        self.assertEqual(cookie['path'], '/custom')
+        self.assertTrue(cookie['secure'])
+        self.assertEqual(cookie['samesite'], 'Strict')
+
+    @override_settings(
+        LOGIN_REQUIRED=False,
+        SESSION_COOKIE_DOMAIN='example.com',
+        SESSION_COOKIE_PATH='/custom',
+        SESSION_COOKIE_SECURE=True,
+        SESSION_COOKIE_SAMESITE='Strict',
+    )
     def test_deactivate_branch(self):
         # Attach the cookie to the test client
         branch = Branch.objects.first()
@@ -44,3 +63,27 @@ class RequestTestCase(TestCase):
         response = self.client.get(f'{url}?{QUERY_PARAM}=')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.client.cookies[COOKIE_NAME].value, '', msg="Cookie was not deleted")
+
+        # Deletion cookie attributes should mirror SESSION_COOKIE_* settings
+        cookie = response.cookies[COOKIE_NAME]
+        self.assertEqual(cookie['domain'], 'example.com')
+        self.assertEqual(cookie['path'], '/custom')
+        self.assertEqual(cookie['samesite'], 'Strict')
+
+    @override_settings(LOGIN_REQUIRED=False)
+    def test_stale_cookie_cleared(self):
+        """
+        A cookie referencing a non-ready branch should be automatically cleared.
+        """
+        branch = Branch.objects.first()
+        branch.status = BranchStatusChoices.ARCHIVED
+        branch.save(provision=False)
+
+        self.client.cookies.load({
+            COOKIE_NAME: branch.schema_id,
+        })
+
+        url = reverse('home')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.cookies[COOKIE_NAME].value, '', msg="Stale cookie was not cleared")


### PR DESCRIPTION
### Fixes: #506 

fixes an issue where the branch cookie was being set without a SameSite attribute. This matters because browsers that don't default to Lax would silently drop the cookie on cross-site navigation, causing branch writes to fall through to the main schema. The fix mirrors Django's SESSION_COOKIE_* settings when setting or deleting the branch cookie, so it behaves consistently with the rest of the session.

The PR also handles stale cookies: if a cookie references a branch that's no longer active (e.g. it was archived or merged since the cookie was set), the middleware now detects this and clears the cookie automatically.