### PR TITLE
513 changediff

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -232,6 +232,8 @@ class ChangeDiff(models.Model):
         """
         Return the set of attributes altered in the branch schema.
         """
+        if self.original is None or self.modified is None:
+            return set()
         return {
             k for k, v in self.modified.items()
             if k in self.original and v != self.original[k]
@@ -272,6 +274,8 @@ class ChangeDiff(models.Model):
         """
         Return a key-value mapping of all attributes in the original state which have been modified.
         """
+        if self.original is None:
+            return {}
         return {
             k: v for k, v in self.original.items()
             if k in self.altered_fields
@@ -282,6 +286,8 @@ class ChangeDiff(models.Model):
         """
         Return a key-value mapping of all attributes which have been modified within the branch.
         """
+        if self.modified is None:
+            return {}
         return {
             k: v for k, v in self.modified.items()
             if k in self.altered_fields

--- a/netbox_branching/tests/test_api.py
+++ b/netbox_branching/tests/test_api.py
@@ -370,3 +370,78 @@ class BranchRevertAPITestCase(BaseBranchAPITestCase, TransactionTestCase):
     action = 'revert'
     valid_status = BranchStatusChoices.MERGED
     invalid_status = BranchStatusChoices.READY
+
+
+class ChangeDiffSerializerTestCase(BaseAPITestCase, TransactionTestCase):
+    """
+    Verify that the ChangeDiff API endpoint serializes CREATE and DELETE records
+    without raising AttributeError when original or modified is None.
+    """
+    serialized_rollback = True
+
+    def setUp(self):
+        super().setUp()
+        self.branch = Branch(name='Test Branch')
+        self.branch.save(provision=False)
+        self.branch.provision(self.user)
+
+    def tearDown(self):
+        connections[self.branch.connection_name].close()
+
+    def _branch_header(self):
+        return {**self.header, 'HTTP_X_NETBOX_BRANCH': self.branch.schema_id}
+
+    def test_changediff_list_create_action(self):
+        """
+        Creating an object inside a branch produces a ChangeDiff with original=None.
+        The changes API must return 200, not 500.
+        """
+        response = self.client.post(
+            reverse('dcim-api:site-list'),
+            data=json.dumps({'name': 'Branch Site', 'slug': 'branch-site'}),
+            content_type='application/json',
+            **self._branch_header(),
+        )
+        self.assertEqual(response.status_code, 201)
+
+        diff = ChangeDiff.objects.get(branch=self.branch)
+        self.assertEqual(diff.action, ObjectChangeActionChoices.ACTION_CREATE)
+        self.assertIsNone(diff.original)
+
+        url = reverse('plugins-api:netbox_branching-api:changediff-list')
+        response = self.client.get(url, **self.header)
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content)['results'][0]
+        self.assertIn('diff', result)
+        self.assertEqual(result['diff'], {'original': {}, 'modified': {}, 'current': {}})
+
+    def test_changediff_list_delete_action(self):
+        """
+        Deleting a pre-existing object inside a branch produces a ChangeDiff with modified=None.
+        The changes API must return 200, not 500.
+        """
+        # Site created before provisioning is present in the branch schema
+        site = Site.objects.create(name='Pre-existing Site', slug='pre-existing-site')
+        branch = Branch(name='Branch With Delete')
+        branch.save(provision=False)
+        branch.provision(self.user)
+
+        try:
+            response = self.client.delete(
+                reverse('dcim-api:site-detail', kwargs={'pk': site.pk}),
+                **{**self.header, 'HTTP_X_NETBOX_BRANCH': branch.schema_id},
+            )
+            self.assertEqual(response.status_code, 204)
+
+            diff = ChangeDiff.objects.get(branch=branch)
+            self.assertEqual(diff.action, ObjectChangeActionChoices.ACTION_DELETE)
+            self.assertIsNone(diff.modified)
+
+            url = reverse('plugins-api:netbox_branching-api:changediff-list')
+            response = self.client.get(url, **self.header)
+            self.assertEqual(response.status_code, 200)
+            result = json.loads(response.content)['results'][0]
+            self.assertIn('diff', result)
+            self.assertEqual(result['diff'], {'original': {}, 'modified': {}, 'current': {}})
+        finally:
+            connections[branch.connection_name].close()

--- a/netbox_branching/tests/test_api.py
+++ b/netbox_branching/tests/test_api.py
@@ -415,6 +415,41 @@ class ChangeDiffSerializerTestCase(BaseAPITestCase, TransactionTestCase):
         self.assertIn('diff', result)
         self.assertEqual(result['diff'], {'original': {}, 'modified': {}, 'current': {}})
 
+    def test_changediff_list_update_action(self):
+        """
+        Updating an object inside a branch produces a ChangeDiff with both original and modified
+        populated. The diff field must reflect only the changed attributes.
+        """
+        # Site created before provisioning is present in the branch schema
+        site = Site.objects.create(name='Original Site', slug='original-site')
+        branch = Branch(name='Branch With Update')
+        branch.save(provision=False)
+        branch.provision(self.user)
+
+        try:
+            response = self.client.patch(
+                reverse('dcim-api:site-detail', kwargs={'pk': site.pk}),
+                data=json.dumps({'description': 'updated in branch'}),
+                content_type='application/json',
+                **{**self.header, 'HTTP_X_NETBOX_BRANCH': branch.schema_id},
+            )
+            self.assertEqual(response.status_code, 200)
+
+            diff = ChangeDiff.objects.get(branch=branch)
+            self.assertEqual(diff.action, ObjectChangeActionChoices.ACTION_UPDATE)
+            self.assertIsNotNone(diff.original)
+            self.assertIsNotNone(diff.modified)
+
+            url = reverse('plugins-api:netbox_branching-api:changediff-list')
+            response = self.client.get(url, **self.header)
+            self.assertEqual(response.status_code, 200)
+            result = json.loads(response.content)['results'][0]
+            self.assertIn('diff', result)
+            self.assertEqual(result['diff']['original']['description'], '')
+            self.assertEqual(result['diff']['modified']['description'], 'updated in branch')
+        finally:
+            connections[branch.connection_name].close()
+
     def test_changediff_list_delete_action(self):
         """
         Deleting a pre-existing object inside a branch produces a ChangeDiff with modified=None.

--- a/netbox_branching/tests/test_changediff.py
+++ b/netbox_branching/tests/test_changediff.py
@@ -99,7 +99,7 @@ class CurrentDiffTestCase(SimpleTestCase):
         self.assertEqual(diff.current_diff, {})
 
     def test_no_changes(self):
-        diff = make_diff(original=DATA_A, modified=DATA_B, current=DATA_A)
+        diff = make_diff(original=DATA_A, modified=DATA_A, current=DATA_A)
         self.assertEqual(diff.current_diff, {})
 
 

--- a/netbox_branching/tests/test_changediff.py
+++ b/netbox_branching/tests/test_changediff.py
@@ -1,0 +1,132 @@
+from django.test import SimpleTestCase
+
+from netbox_branching.models import ChangeDiff
+
+DATA_A = {'name': 'foo', 'description': ''}
+DATA_B = {'name': 'foo', 'description': 'changed'}
+DATA_C = {'name': 'foo', 'description': 'main change'}
+
+
+def make_diff(**kwargs):
+    """Return an un-saved ChangeDiff with only the JSON fields set."""
+    return ChangeDiff(
+        original=kwargs.get('original', DATA_A),
+        modified=kwargs.get('modified', DATA_B),
+        current=kwargs.get('current', None),
+    )
+
+
+class AlteredInModifiedTestCase(SimpleTestCase):
+
+    def test_returns_changed_keys(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B)
+        self.assertEqual(diff.altered_in_modified, {'description'})
+
+    def test_no_changes(self):
+        diff = make_diff(original=DATA_A, modified=DATA_A)
+        self.assertEqual(diff.altered_in_modified, set())
+
+    def test_original_none(self):
+        # CREATE action — original is None
+        diff = make_diff(original=None, modified=DATA_B)
+        self.assertEqual(diff.altered_in_modified, set())
+
+    def test_modified_none(self):
+        # DELETE action — modified is None
+        diff = make_diff(original=DATA_A, modified=None)
+        self.assertEqual(diff.altered_in_modified, set())
+
+    def test_both_none(self):
+        diff = make_diff(original=None, modified=None)
+        self.assertEqual(diff.altered_in_modified, set())
+
+
+class AlteredInCurrentTestCase(SimpleTestCase):
+
+    def test_returns_changed_keys(self):
+        diff = make_diff(original=DATA_A, current=DATA_C)
+        self.assertEqual(diff.altered_in_current, {'description'})
+
+    def test_no_changes(self):
+        diff = make_diff(original=DATA_A, current=DATA_A)
+        self.assertEqual(diff.altered_in_current, set())
+
+    def test_current_none(self):
+        diff = make_diff(original=DATA_A, current=None)
+        self.assertEqual(diff.altered_in_current, set())
+
+
+class OriginalDiffTestCase(SimpleTestCase):
+
+    def test_returns_altered_fields(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B)
+        self.assertEqual(diff.original_diff, {'description': ''})
+
+    def test_original_none(self):
+        # CREATE action — original is None
+        diff = make_diff(original=None, modified=DATA_B)
+        self.assertEqual(diff.original_diff, {})
+
+    def test_no_changes(self):
+        diff = make_diff(original=DATA_A, modified=DATA_A)
+        self.assertEqual(diff.original_diff, {})
+
+
+class ModifiedDiffTestCase(SimpleTestCase):
+
+    def test_returns_altered_fields(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B)
+        self.assertEqual(diff.modified_diff, {'description': 'changed'})
+
+    def test_modified_none(self):
+        # DELETE action — modified is None
+        diff = make_diff(original=DATA_A, modified=None)
+        self.assertEqual(diff.modified_diff, {})
+
+    def test_no_changes(self):
+        diff = make_diff(original=DATA_A, modified=DATA_A)
+        self.assertEqual(diff.modified_diff, {})
+
+
+class CurrentDiffTestCase(SimpleTestCase):
+
+    def test_returns_altered_fields(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B, current=DATA_C)
+        self.assertEqual(diff.current_diff, {'description': 'main change'})
+
+    def test_current_none(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B, current=None)
+        self.assertEqual(diff.current_diff, {})
+
+    def test_no_changes(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B, current=DATA_A)
+        self.assertEqual(diff.current_diff, {})
+
+
+class DiffPropertyTestCase(SimpleTestCase):
+    """
+    Verify the composite diff property doesn't raise for any None combination.
+    """
+
+    def test_create_action(self):
+        # original=None, modified=data — CREATE
+        diff = make_diff(original=None, modified=DATA_B)
+        result = diff.diff
+        self.assertEqual(result['original'], {})
+        self.assertEqual(result['modified'], {})
+        self.assertEqual(result['current'], {})
+
+    def test_delete_action(self):
+        # original=data, modified=None — DELETE
+        diff = make_diff(original=DATA_A, modified=None)
+        result = diff.diff
+        self.assertEqual(result['original'], {})
+        self.assertEqual(result['modified'], {})
+        self.assertEqual(result['current'], {})
+
+    def test_update_action(self):
+        diff = make_diff(original=DATA_A, modified=DATA_B, current=DATA_C)
+        result = diff.diff
+        self.assertEqual(result['original'], {'description': ''})
+        self.assertEqual(result['modified'], {'description': 'changed'})
+        self.assertEqual(result['current'], {'description': 'main change'})


### PR DESCRIPTION
### Fixes: #513 

The diff field was silently dropped from the API response for any ChangeDiff record with a CREATE or DELETE action. For CREATE records original is None, and for DELETE records modified is None. The three cached properties `altered_in_modified`, `original_diff`, and `modified_diff` called .items() on those fields without null guards, raising AttributeError. 

Because Python's attribute lookup treats AttributeError from a descriptor as "attribute not found", DRF silently omitted diff from the serialized output rather than returning a 500. The fix adds null guards matching the pattern already used by altered_in_current and current_diff.

Tests are added specifically for the ChangeDiff diff function making sure its returns are correct and API test cases are added that show this issue. Note: `test_changediff_list_update_action` does not show this error but is included for completeness for a full CRUD test for returned data.