### PR TITLE
#494 allow merge branch if file missing from S3 storage

### DIFF
--- a/netbox_branching/constants.py
+++ b/netbox_branching/constants.py
@@ -1,5 +1,11 @@
 from django.urls import reverse_lazy
 
+try:
+    from botocore.exceptions import ClientError as BotocoreClientError
+    _FILE_NOT_FOUND_EXCEPTIONS = (FileNotFoundError, BotocoreClientError)
+except ImportError:
+    _FILE_NOT_FOUND_EXCEPTIONS = (FileNotFoundError,)
+
 __all__ = (
     'BRANCH_ACTIONS',
     'BRANCH_HEADER',

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -66,7 +66,8 @@ class ObjectChange(ObjectChange_):
                 # so we need to ignore it. We can assume the NetBox state is valid.
                 # For S3 ClientError, suppress key-not-found responses (404) and access-denied
                 # responses (403), since S3 can be configured to return 403 for missing objects.
-                if hasattr(e, 'response') and e.response.get('ResponseMetadata', {}).get('HTTPStatusCode') not in (403, 404):
+                status = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode') if hasattr(e, 'response') else None
+                if status not in (403, 404):
                     raise
                 logger.warning(f'Ignoring missing file: {e}')
             instance.save(using=using)

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -1,12 +1,6 @@
 import logging
 from functools import cached_property
 
-try:
-    from botocore.exceptions import ClientError as BotocoreClientError
-    _FILE_NOT_FOUND_EXCEPTIONS = (FileNotFoundError, BotocoreClientError)
-except ImportError:
-    _FILE_NOT_FOUND_EXCEPTIONS = (FileNotFoundError,)
-
 from core.choices import ObjectChangeActionChoices
 from core.models import ObjectChange as ObjectChange_
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -17,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from utilities.querysets import RestrictedQuerySet
 from utilities.serialization import deserialize_object
 
+from netbox_branching.constants import _FILE_NOT_FOUND_EXCEPTIONS
 from netbox_branching.utilities import update_object
 
 __all__ = (

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -11,8 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from utilities.querysets import RestrictedQuerySet
 from utilities.serialization import deserialize_object
 
-from netbox_branching.constants import _FILE_NOT_FOUND_EXCEPTIONS
-from netbox_branching.utilities import update_object
+from netbox_branching.utilities import full_clean_with_file_check, update_object
 
 __all__ = (
     'AppliedChange',
@@ -54,18 +53,7 @@ class ObjectChange(ObjectChange_):
                 instance = model.deserialize_object(self.postchange_data, pk=self.changed_object_id)
             else:
                 instance = deserialize_object(model, self.postchange_data, pk=self.changed_object_id)
-            try:
-                instance.object.full_clean()
-            except _FILE_NOT_FOUND_EXCEPTIONS as e:
-                # If a file was deleted later in this branch it will fail here
-                # so we need to ignore it. We can assume the NetBox state is valid.
-                # For S3 ClientError, suppress key-not-found responses (404) and access-denied
-                # responses (403), since S3 can be configured to return 403 for missing objects.
-                if hasattr(e, 'response'):
-                    status = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
-                    if status not in (403, 404):
-                        raise
-                logger.warning(f'Ignoring missing file: {e}')
+            full_clean_with_file_check(instance.object, logger)
             instance.save(using=using)
 
         # Modifying an object

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -1,6 +1,12 @@
 import logging
 from functools import cached_property
 
+try:
+    from botocore.exceptions import ClientError as BotocoreClientError
+    _FILE_NOT_FOUND_EXCEPTIONS = (FileNotFoundError, BotocoreClientError)
+except ImportError:
+    _FILE_NOT_FOUND_EXCEPTIONS = (FileNotFoundError,)
+
 from core.choices import ObjectChangeActionChoices
 from core.models import ObjectChange as ObjectChange_
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -55,9 +61,10 @@ class ObjectChange(ObjectChange_):
                 instance = deserialize_object(model, self.postchange_data, pk=self.changed_object_id)
             try:
                 instance.object.full_clean()
-            except (FileNotFoundError) as e:
+            except _FILE_NOT_FOUND_EXCEPTIONS as e:
                 # If a file was deleted later in this branch it will fail here
                 # so we need to ignore it. We can assume the NetBox state is valid.
+                # Also catches S3 storage errors (botocore.exceptions.ClientError).
                 logger.warning(f'Ignoring missing file: {e}')
             instance.save(using=using)
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -66,9 +66,10 @@ class ObjectChange(ObjectChange_):
                 # so we need to ignore it. We can assume the NetBox state is valid.
                 # For S3 ClientError, suppress key-not-found responses (404) and access-denied
                 # responses (403), since S3 can be configured to return 403 for missing objects.
-                status = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode') if hasattr(e, 'response') else None
-                if status is not None and status not in (403, 404):
-                    raise
+                if hasattr(e, 'response'):
+                    status = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
+                    if status not in (403, 404):
+                        raise
                 logger.warning(f'Ignoring missing file: {e}')
             instance.save(using=using)
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -67,7 +67,7 @@ class ObjectChange(ObjectChange_):
                 # For S3 ClientError, suppress key-not-found responses (404) and access-denied
                 # responses (403), since S3 can be configured to return 403 for missing objects.
                 status = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode') if hasattr(e, 'response') else None
-                if status not in (403, 404):
+                if status is not None and status not in (403, 404):
                     raise
                 logger.warning(f'Ignoring missing file: {e}')
             instance.save(using=using)

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -64,7 +64,10 @@ class ObjectChange(ObjectChange_):
             except _FILE_NOT_FOUND_EXCEPTIONS as e:
                 # If a file was deleted later in this branch it will fail here
                 # so we need to ignore it. We can assume the NetBox state is valid.
-                # Also catches S3 storage errors (botocore.exceptions.ClientError).
+                # For S3 ClientError, suppress key-not-found responses (404) and access-denied
+                # responses (403), since S3 can be configured to return 403 for missing objects.
+                if hasattr(e, 'response') and e.response.get('ResponseMetadata', {}).get('HTTPStatusCode') not in (403, 404):
+                    raise
                 logger.warning(f'Ignoring missing file: {e}')
             instance.save(using=using)
 

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -17,6 +17,7 @@ from netbox.utils import register_request_processor
 
 from .constants import BRANCH_HEADER, COOKIE_NAME, EXEMPT_MODELS, EXEMPT_PATHS, INCLUDE_MODELS, QUERY_PARAM
 from .contextvars import active_branch
+from .models.changes import _FILE_NOT_FOUND_EXCEPTIONS
 
 # Thread-local storage for tracking branch connection aliases (matches Django's approach)
 # Note: Aliases are tracked once and never removed, matching Django's pattern where
@@ -250,7 +251,7 @@ def update_object(instance, data, using):
 
     try:
         instance.full_clean()
-    except (FileNotFoundError) as e:
+    except _FILE_NOT_FOUND_EXCEPTIONS as e:
         # If a file was deleted later in this branch it will fail here
         # so we need to ignore it. We can assume the NetBox state is valid.
         logger.warning(f'Ignoring missing file: {e}')

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -15,9 +15,16 @@ from django.urls import reverse
 from netbox.plugins import get_plugin_config
 from netbox.utils import register_request_processor
 
-from .constants import BRANCH_HEADER, COOKIE_NAME, EXEMPT_MODELS, EXEMPT_PATHS, INCLUDE_MODELS, QUERY_PARAM
+from .constants import (
+    _FILE_NOT_FOUND_EXCEPTIONS,
+    BRANCH_HEADER,
+    COOKIE_NAME,
+    EXEMPT_MODELS,
+    EXEMPT_PATHS,
+    INCLUDE_MODELS,
+    QUERY_PARAM,
+)
 from .contextvars import active_branch
-from .models.changes import _FILE_NOT_FOUND_EXCEPTIONS
 
 # Thread-local storage for tracking branch connection aliases (matches Django's approach)
 # Note: Aliases are tracked once and never removed, matching Django's pattern where

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -40,6 +40,7 @@ __all__ = (
     'activate_branch',
     'close_old_branch_connections',
     'deactivate_branch',
+    'full_clean_with_file_check',
     'get_active_branch',
     'get_branchable_object_types',
     'get_sql_results',
@@ -225,6 +226,22 @@ class ChangeSummary:
     count: int
 
 
+def full_clean_with_file_check(instance, logger):
+    """
+    Calls instance.full_clean(), suppressing _FILE_NOT_FOUND_EXCEPTIONS for genuinely missing
+    files. For BotocoreClientError, only 403/404 responses are suppressed — S3 can return 403
+    for missing objects when the bucket policy denies s3:ListBucket.
+    """
+    try:
+        instance.full_clean()
+    except _FILE_NOT_FOUND_EXCEPTIONS as e:
+        if hasattr(e, 'response'):
+            status = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
+            if status not in (403, 404):
+                raise
+        logger.warning(f'Ignoring missing file: {e}')
+
+
 def update_object(instance, data, using):
     """
     Set an attribute on an object depending on the type of model field.
@@ -256,12 +273,7 @@ def update_object(instance, data, using):
         else:
             setattr(instance, attr, value)
 
-    try:
-        instance.full_clean()
-    except _FILE_NOT_FOUND_EXCEPTIONS as e:
-        # If a file was deleted later in this branch it will fail here
-        # so we need to ignore it. We can assume the NetBox state is valid.
-        logger.warning(f'Ignoring missing file: {e}')
+    full_clean_with_file_check(instance, logger)
     instance.save(using=using)
 
     for m2m_manager, value in m2m_assignments.items():


### PR DESCRIPTION
### Fixes: #494 

Note that S3 needs to be configured to return 403 instead of 404 for unknown file, which is a security practice called bucket enumeration prevention.

This means a genuine misconfigured IAM policy (where the credentials truly lack access to the bucket) would also be silently swallowed and logged as "Ignoring missing file."  But given the context - this code runs during a merge, where the files were already successfully written during normal branch operation - a 403 on HeadObject at merge time is almost certainly the S3 enumeration-protection behavior, not a credentials problem. A real credential failure would have surfaced much earlier when the file was first saved.