### PR TITLE
Fixes #519: Disable Merge button on branches with no changes

### DIFF
--- a/netbox_branching/templates/netbox_branching/buttons/branch_merge.html
+++ b/netbox_branching/templates/netbox_branching/buttons/branch_merge.html
@@ -1,10 +1,12 @@
 {% load i18n %}
-{% if perms.netbox_branching.merge_branch %}
+{% if perms.netbox_branching.merge_branch and branch.get_unmerged_changes.exists %}
   <a href="{% url 'plugins:netbox_branching:branch_merge' pk=branch.pk %}" class="btn btn-primary">
     <i class="mdi mdi-merge"></i> {% trans "Merge" %}
   </a>
 {% else %}
-  <button type="button" class="btn btn-primary disabled" aria-disabled="true">
-    <i class="mdi mdi-merge"></i> {% trans "Merge" %}
-  </button>
+  <span class="inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-delay="100" data-bs-placement="bottom" title="{% if not perms.netbox_branching.merge_branch %}{% trans "Insufficient permissions" %}{% else %}{% trans "No changes to merge" %}{% endif %}">
+    <button type="button" class="btn btn-primary disabled" aria-disabled="true">
+      <i class="mdi mdi-merge"></i> {% trans "Merge" %}
+    </button>
+  </span>
 {% endif %}

--- a/netbox_branching/templates/netbox_branching/buttons/branch_merge.html
+++ b/netbox_branching/templates/netbox_branching/buttons/branch_merge.html
@@ -4,7 +4,7 @@
     <i class="mdi mdi-merge"></i> {% trans "Merge" %}
   </a>
 {% else %}
-  <span class="inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-delay="100" data-bs-placement="bottom" title="{% if not perms.netbox_branching.merge_branch %}{% trans "Insufficient permissions" %}{% else %}{% trans "No changes to merge" %}{% endif %}">
+  <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-delay="100" data-bs-placement="bottom" title="{% if not perms.netbox_branching.merge_branch %}{% trans "Insufficient permissions" %}{% else %}{% trans "No changes to merge" %}{% endif %}">
     <button type="button" class="btn btn-primary disabled" aria-disabled="true">
       <i class="mdi mdi-merge"></i> {% trans "Merge" %}
     </button>


### PR DESCRIPTION
### Fixes: #519

Check `branch.get_unmerged_changes().exists()` before enabling the Merge button. When no changes exist, render a disabled button with a Bootstrap tooltip explaining why ("No changes to merge" or "Insufficient permissions"). Uses the same span-wrapper tooltip pattern as NetBox core's `datasource.html`.

### Testing

- [ ] Branch detail: branch with unmerged changes shows active Merge button
- [ ] Branch detail: branch with no changes shows disabled Merge button with "No changes to merge" tooltip
- [ ] Branch detail: user without merge permission sees disabled Merge button with "Insufficient permissions" tooltip
- [ ] CR detail (approved): branch with changes shows active Merge button
- [ ] CR detail (approved): branch with no changes shows disabled Merge button with "No changes to merge" tooltip
- [ ] CR detail (not approved): Merge button not rendered (existing `is_approved` gate, unchanged)
