### PR TITLE
Fixes #522: Share button toast, typo, and i18n for activation messages

### DIFF
--- a/netbox_branching/middleware.py
+++ b/netbox_branching/middleware.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
+from django.utils.translation import gettext as _
 
 from .constants import COOKIE_NAME, EXEMPT_PATHS, QUERY_PARAM
 from .utilities import get_active_branch, is_api_request
@@ -72,7 +73,9 @@ class BranchMiddleware:
                 requested_url = request.path
                 messages.warning(
                     request,
-                    f"The requested object at {requested_url} does not exist in {branch_name}."
+                    _("The requested object at {url} does not exist in {branch_name}.").format(
+                        url=requested_url, branch_name=branch_name
+                    )
                 )
 
                 # Create redirect response and apply cookie operations to it

--- a/netbox_branching/templates/netbox_branching/inc/share_button.html
+++ b/netbox_branching/templates/netbox_branching/inc/share_button.html
@@ -1,6 +1,6 @@
 {% if active_branch %}
     {% load i18n %}
-    <a href="{{ object.get_absolute_url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue" title="{% trans "Link to the this page in the current branch" %} ({{ active_branch.name }})">
+    <a href="{{ object.get_absolute_url }}?_branch={{ active_branch.schema_id }}" type="button" class="btn btn-outline-blue" title="{% trans "Link to this page in the current branch" %} ({{ active_branch.name }})">
         <i class="mdi mdi-share"></i> {% trans "Share" %}
     </a>
 {% endif %}

--- a/netbox_branching/tests/test_request.py
+++ b/netbox_branching/tests/test_request.py
@@ -44,6 +44,10 @@ class RequestTestCase(TestCase):
         self.assertTrue(cookie['secure'])
         self.assertEqual(cookie['samesite'], 'Strict')
 
+        # Verify exactly one activation toast (not duplicated by the request processor)
+        messages_list = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages_list), 1, msg="Expected exactly one activation toast message")
+
     @override_settings(
         LOGIN_REQUIRED=False,
         SESSION_COOKIE_DOMAIN='example.com',

--- a/netbox_branching/tests/test_request.py
+++ b/netbox_branching/tests/test_request.py
@@ -71,6 +71,19 @@ class RequestTestCase(TestCase):
         self.assertEqual(cookie['samesite'], 'Strict')
 
     @override_settings(LOGIN_REQUIRED=False)
+    def test_reactivate_branch_no_message(self):
+        branch = Branch.objects.first()
+        self.client.cookies.load({
+            COOKIE_NAME: branch.schema_id,
+        })
+
+        url = reverse('home')
+        response = self.client.get(f'{url}?{QUERY_PARAM}={branch.schema_id}')
+        self.assertEqual(response.status_code, 200)
+        messages_list = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages_list), 0, msg="Unexpected toast message on branch re-activation")
+
+    @override_settings(LOGIN_REQUIRED=False)
     def test_stale_cookie_cleared(self):
         """
         A cookie referencing a non-ready branch should be automatically cleared.

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -12,6 +12,7 @@ from django.db import connections
 from django.db.models import ForeignKey, ManyToManyField
 from django.http import HttpResponseBadRequest
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from netbox.plugins import get_plugin_config
 from netbox.utils import register_request_processor
 
@@ -316,11 +317,14 @@ def get_active_branch(request):
         if schema_id := request.GET.get(QUERY_PARAM):
             branch = Branch.objects.get(schema_id=schema_id)
             if branch.ready:
-                messages.success(request, f"Activated branch {branch}")
+                if schema_id != request.COOKIES.get(COOKIE_NAME):
+                    messages.success(request, _("Activated branch {branch}").format(branch=branch))
                 return branch
-            messages.error(request, f"Branch {branch} is not ready for use (status: {branch.status})")
+            messages.error(request, _("Branch {branch} is not ready for use (status: {status})").format(
+                branch=branch, status=branch.status
+            ))
             return None
-        messages.success(request, "Deactivated branch")
+        messages.success(request, _("Deactivated branch"))
         request.COOKIES.pop(COOKIE_NAME, None)  # Delete cookie if set
         return None
 

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -318,13 +318,19 @@ def get_active_branch(request):
             branch = Branch.objects.get(schema_id=schema_id)
             if branch.ready:
                 if schema_id != request.COOKIES.get(COOKIE_NAME):
-                    messages.success(request, _("Activated branch {branch}").format(branch=branch))
+                    if not getattr(request, '_branch_activation_notified', False):
+                        messages.success(request, _("Activated branch {branch}").format(branch=branch))
+                        request._branch_activation_notified = True
                 return branch
-            messages.error(request, _("Branch {branch} is not ready for use (status: {status})").format(
-                branch=branch, status=branch.status
-            ))
+            if not getattr(request, '_branch_activation_notified', False):
+                messages.error(request, _("Branch {branch} is not ready for use (status: {status})").format(
+                    branch=branch, status=branch.status
+                ))
+                request._branch_activation_notified = True
             return None
-        messages.success(request, _("Deactivated branch"))
+        if not getattr(request, '_branch_activation_notified', False):
+            messages.success(request, _("Deactivated branch"))
+            request._branch_activation_notified = True
         request.COOKIES.pop(COOKIE_NAME, None)  # Delete cookie if set
         return None
 

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -317,10 +317,12 @@ def get_active_branch(request):
         if schema_id := request.GET.get(QUERY_PARAM):
             branch = Branch.objects.get(schema_id=schema_id)
             if branch.ready:
-                if schema_id != request.COOKIES.get(COOKIE_NAME):
-                    if not getattr(request, '_branch_activation_notified', False):
-                        messages.success(request, _("Activated branch {branch}").format(branch=branch))
-                        request._branch_activation_notified = True
+                if (
+                    schema_id != request.COOKIES.get(COOKIE_NAME)
+                    and not getattr(request, '_branch_activation_notified', False)
+                ):
+                    messages.success(request, _("Activated branch {branch}").format(branch=branch))
+                    request._branch_activation_notified = True
                 return branch
             if not getattr(request, '_branch_activation_notified', False):
                 messages.error(request, _("Branch {branch} is not ready for use (status: {status})").format(


### PR DESCRIPTION
### Fixes: #522

- Suppress the redundant "Activated branch" toast when clicking the share button for an already-active branch (compares query param against cookie)
- Fix "Link to the this page" typo in share button tooltip
- Wrap all activation/deactivation messages in `gettext()` for i18n (utilities.py and middleware.py)
- Add test for the toast suppression behavior