### PR TITLE
#533 Fix check_object_accessible_in_branch 

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -55,13 +55,8 @@ def check_object_accessible_in_branch(branch, model, object_id):
     if f'{model._meta.app_label}.{model._meta.model_name}' in INCLUDE_MODELS:
         return True
 
-    # Check whether the object exists in main
     with deactivate_branch():
-        try:
-            model.objects.get(pk=object_id)
-        except model.DoesNotExist:
-            pass
-        else:
+        if model.objects.filter(pk=object_id).exists():
             return True
 
     # Object doesn't exist in main - check if it was created in the branch

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -55,6 +55,7 @@ def check_object_accessible_in_branch(branch, model, object_id):
     if f'{model._meta.app_label}.{model._meta.model_name}' in INCLUDE_MODELS:
         return True
 
+    # Check whether the object exists in main
     with deactivate_branch():
         if model.objects.filter(pk=object_id).exists():
             return True


### PR DESCRIPTION
### Fixes: #533 

Change to use and exist() check instead of a try, get, except.  This is cheaper operation and doesn't load all the model fields which was causing issues in the revert in branching for custom objects as the schema was different between the states of the object as they are dynamically created and only one is in memory at once.