### PR TITLE
allow plugins to register include_models

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -71,6 +71,90 @@ exempt_models = ['my_plugin.*']
 
 See [Configuration: `exempt_models`](configuration.md#exempt_models) for full details.
 
+## Opting In: `register_branching_resolver`
+
+Some plugins have models that are not `ChangeLoggingMixin` subclasses but still need to participate in branching — most commonly **dynamically-generated M2M through tables** that store relationships involving branchable parent objects.
+
+The default branching heuristic excludes any model that does not inherit `ChangeLoggingMixin`, on the assumption that such models are configuration-style records (singletons, choice sets, etc.) that should remain global. For a through table, that assumption is wrong: relationship rows for a branch-only parent must live in the branch schema, not in main, or foreign-key constraints will fail and the relationship will leak across branches.
+
+NetBox Branching ships with a static list (`INCLUDE_MODELS`) covering its own through tables (`extras.taggeditem`, `dcim.portmapping`, etc.). For plugin models — especially when the model name isn't known until runtime — you can register a callable that decides on each query whether a given model should be branchable.
+
+### Resolver Signature
+
+A resolver is a plain function that takes a model class and returns `True`, `False`, or `None`:
+
+```python
+def my_resolver(model) -> bool | None:
+    ...
+```
+
+| Return value | Meaning |
+|---|---|
+| `True`  | Model is branchable; route queries to the active branch (still subject to the `exempt_models` filter). |
+| `False` | Model is not branchable; always route to main. |
+| `None`  | Defer to the next resolver, or to the default `ChangeLoggingMixin` heuristic. |
+
+Resolvers are evaluated in registration order. The first non-`None` result wins. Returning `None` for models you don't care about is important — it lets other plugins' resolvers, and the default heuristic, run normally.
+
+### Registration
+
+Register from your `PluginConfig.ready()`. Wrap the import in `try/except ImportError` so your plugin still works when `netbox-branching` is not installed:
+
+```python
+# my_plugin/__init__.py
+from netbox.plugins import PluginConfig
+
+
+class MyPluginConfig(PluginConfig):
+    name = 'my_plugin'
+    # ...
+
+    def ready(self):
+        super().ready()
+        try:
+            from netbox_branching.utilities import register_branching_resolver
+            from .branching import my_resolver
+            register_branching_resolver(my_resolver)
+        except ImportError:
+            pass  # netbox-branching not installed; nothing to register
+```
+
+`ready()` runs once per worker process at startup, so registration happens exactly once and the resolver list does not need to be deduplicated.
+
+### Example: Dynamically-generated through table
+
+A plugin that creates M2M through tables at runtime — for example `through_my_plugin_<n>_<field>` — can mark them branchable based on a name pattern:
+
+```python
+# my_plugin/branching.py
+
+def supports_branching_resolver(model):
+    """Mark dynamically-generated M2M through tables as branchable."""
+    meta = getattr(model, '_meta', None)
+    if meta is None or meta.app_label != 'my_plugin':
+        return None
+    if (meta.model_name or '').startswith('through_my_plugin_'):
+        return True
+    return None
+```
+
+Registered as above, this routes all matching through-table queries to the active branch's schema. Without it, the through-row INSERT would land in main and fail on the foreign-key constraint to a branch-only parent row.
+
+### When to use it
+
+- A model lacks `ChangeLoggingMixin` but **must** be branchable because it stores relationships or denormalized state for branchable parent objects.
+- The model name or app label can be matched dynamically (a name pattern, a class attribute, etc.) and so can't be expressed as a static entry in `INCLUDE_MODELS`.
+
+### When *not* to use it
+
+- The model already inherits `ChangeLoggingMixin`. Branching support is automatic in that case.
+- The model is a singleton / configuration record that should remain global. Leave it alone — the default heuristic will keep it in main.
+- You only need to bypass branching for a single specific model. Use `exempt_models` instead; it's simpler and more discoverable.
+
+### Interaction with `exempt_models`
+
+A resolver returning `True` does **not** override the `exempt_models` filter. After a resolver opts a model in, `supports_branching` still applies the configured exempt list. So you can use the two together: register a resolver that includes a whole class of plugin models, then exempt specific ones via `PLUGINS_CONFIG`.
+
 ## Custom Validators
 
 NetBox Branching supports pluggable validator functions that run before each branch action (sync, merge, revert, archive). This allows you or other plugin authors to enforce business rules — for example, preventing a branch from being merged if it has unresolved issues in an external system.

--- a/netbox_branching/tests/test_branching_resolver.py
+++ b/netbox_branching/tests/test_branching_resolver.py
@@ -57,9 +57,9 @@ class RegisterBranchingResolverTestCase(TestCase):
 
     def test_multiple_registrations_preserve_order(self):
         with _isolated_resolvers():
-            r1 = lambda model: None  # noqa: E731
-            r2 = lambda model: None  # noqa: E731
-            r3 = lambda model: None  # noqa: E731
+            r1 = lambda model: None
+            r2 = lambda model: None
+            r3 = lambda model: None
             register_branching_resolver(r1)
             register_branching_resolver(r2)
             register_branching_resolver(r3)

--- a/netbox_branching/tests/test_branching_resolver.py
+++ b/netbox_branching/tests/test_branching_resolver.py
@@ -1,0 +1,176 @@
+"""
+Tests for the ``register_branching_resolver`` plugin extension point.
+
+The resolver list lives at module level on ``netbox_branching.utilities``;
+each test snapshots and restores it so registrations don't leak between
+tests.
+"""
+from contextlib import contextmanager
+
+from django.contrib.auth.models import Group
+from django.test import TestCase
+from ipam.models import Prefix
+
+from netbox_branching import utilities
+from netbox_branching.utilities import (
+    register_branching_resolver,
+    supports_branching,
+)
+
+
+@contextmanager
+def _isolated_resolvers():
+    """Snapshot ``_branching_resolvers`` and restore it on exit."""
+    saved = list(utilities._branching_resolvers)
+    utilities._branching_resolvers.clear()
+    try:
+        yield
+    finally:
+        utilities._branching_resolvers.clear()
+        utilities._branching_resolvers.extend(saved)
+
+
+class RegisterBranchingResolverTestCase(TestCase):
+    """``register_branching_resolver`` input validation."""
+
+    def test_register_callable(self):
+        with _isolated_resolvers():
+            def resolver(model):
+                return None
+            register_branching_resolver(resolver)
+            self.assertIn(resolver, utilities._branching_resolvers)
+
+    def test_register_non_callable_raises(self):
+        with _isolated_resolvers():
+            with self.assertRaises(TypeError):
+                register_branching_resolver('not callable')
+            with self.assertRaises(TypeError):
+                register_branching_resolver(42)
+            with self.assertRaises(TypeError):
+                register_branching_resolver(None)
+            self.assertEqual(utilities._branching_resolvers, [])
+
+    def test_register_lambda(self):
+        with _isolated_resolvers():
+            register_branching_resolver(lambda model: None)
+            self.assertEqual(len(utilities._branching_resolvers), 1)
+
+    def test_multiple_registrations_preserve_order(self):
+        with _isolated_resolvers():
+            r1 = lambda model: None  # noqa: E731
+            r2 = lambda model: None  # noqa: E731
+            r3 = lambda model: None  # noqa: E731
+            register_branching_resolver(r1)
+            register_branching_resolver(r2)
+            register_branching_resolver(r3)
+            self.assertEqual(utilities._branching_resolvers, [r1, r2, r3])
+
+
+class ResolverDispatchTestCase(TestCase):
+    """``supports_branching`` integration with registered resolvers."""
+
+    def test_resolver_returning_true_opts_model_in(self):
+        """A resolver returning True branches a model that wouldn't be by default.
+
+        ``auth.Group`` is not a ChangeLoggingMixin subclass and not in
+        INCLUDE_MODELS, so supports_branching returns False by default.  A
+        resolver returning True should flip that result.
+        """
+        # Baseline: not branchable without resolver
+        self.assertFalse(supports_branching(Group))
+
+        with _isolated_resolvers():
+            def resolver(model):
+                if model is Group:
+                    return True
+                return None
+            register_branching_resolver(resolver)
+            self.assertTrue(supports_branching(Group))
+
+    def test_resolver_returning_false_opts_model_out(self):
+        """A resolver returning False excludes a model that's branchable by default.
+
+        ``ipam.Prefix`` is a ChangeLoggingMixin subclass so supports_branching
+        returns True by default.  A resolver returning False should override
+        that decision.
+        """
+        # Baseline: branchable without resolver
+        self.assertTrue(supports_branching(Prefix))
+
+        with _isolated_resolvers():
+            def resolver(model):
+                if model is Prefix:
+                    return False
+                return None
+            register_branching_resolver(resolver)
+            self.assertFalse(supports_branching(Prefix))
+
+    def test_resolver_returning_none_falls_through(self):
+        """A resolver returning None should not affect the default decision."""
+        with _isolated_resolvers():
+            def resolver(model):
+                return None
+            register_branching_resolver(resolver)
+            # ChangeLoggingMixin-based model still branchable
+            self.assertTrue(supports_branching(Prefix))
+            # Non-ChangeLoggingMixin model still excluded
+            self.assertFalse(supports_branching(Group))
+
+    def test_first_non_none_wins(self):
+        """Resolvers run in registration order; first non-None decides."""
+        with _isolated_resolvers():
+            register_branching_resolver(lambda m: None)         # defers
+            register_branching_resolver(lambda m: True)         # decides
+            register_branching_resolver(lambda m: False)        # never reached
+            self.assertTrue(supports_branching(Group))
+
+    def test_raising_resolver_is_swallowed(self):
+        """A resolver that raises is logged and treated as None."""
+        def bad_resolver(model):
+            raise RuntimeError('boom')
+
+        with _isolated_resolvers():
+            register_branching_resolver(bad_resolver)
+            with self.assertLogs('netbox_branching.utilities', level='ERROR') as cm:
+                # Falls through to default heuristic.
+                self.assertTrue(supports_branching(Prefix))
+                self.assertFalse(supports_branching(Group))
+            joined = '\n'.join(cm.output)
+            self.assertIn('boom', joined)
+            self.assertIn('treating as None', joined)
+
+    def test_raising_resolver_does_not_block_subsequent_resolvers(self):
+        """A raising resolver should not prevent the next resolver from running."""
+        def bad_resolver(model):
+            raise RuntimeError('boom')
+
+        with _isolated_resolvers():
+            register_branching_resolver(bad_resolver)
+            register_branching_resolver(lambda m: True if m is Group else None)
+            with self.assertLogs('netbox_branching.utilities', level='ERROR'):
+                self.assertTrue(supports_branching(Group))
+
+    def test_include_models_takes_precedence_over_resolver(self):
+        """``INCLUDE_MODELS`` runs before resolvers; a False resolver can't override it.
+
+        ``extras.taggeditem`` is in INCLUDE_MODELS, so even a resolver returning
+        False should not exclude it.
+        """
+        from extras.models import TaggedItem
+        with _isolated_resolvers():
+            register_branching_resolver(lambda m: False)
+            self.assertTrue(supports_branching(TaggedItem))
+
+    def test_exempt_models_filter_still_runs_after_resolver(self):
+        """A resolver returning True is still subject to ``exempt_models``."""
+        from django.test import override_settings
+
+        with _isolated_resolvers():
+            register_branching_resolver(lambda m: True if m is Group else None)
+            # Without exempt_models: resolver opts Group in.
+            self.assertTrue(supports_branching(Group))
+            # With exempt_models matching Group: exempt wins.
+            with override_settings(PLUGINS_CONFIG={
+                'netbox_branching': {'exempt_models': ['auth.group']},
+            }):
+                self.assertFalse(supports_branching(Group))

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -27,6 +27,8 @@ from .constants import (
 )
 from .contextvars import active_branch
 
+logger = logging.getLogger(__name__)
+
 # Thread-local storage for tracking branch connection aliases (matches Django's approach)
 # Note: Aliases are tracked once and never removed, matching Django's pattern where
 # DATABASES.keys() is static. Memory overhead is negligible (string references only).
@@ -48,6 +50,7 @@ __all__ = (
     'get_tables_to_replicate',
     'is_api_request',
     'record_applied_change',
+    'register_branching_resolver',
     'resolve_changes_summary',
     'supports_branching',
     'track_branch_connection',
@@ -174,7 +177,7 @@ def register_branching_resolver(resolver):
     The first non-``None`` return wins.
     """
     if not callable(resolver):
-        raise TypeError("Branching resolver must be callable")
+        raise TypeError('Branching resolver must be callable')
     _branching_resolvers.append(resolver)
 
 
@@ -198,9 +201,7 @@ def supports_branching(model):
         try:
             result = resolver(model)
         except Exception:
-            logging.getLogger('netbox_branching.utilities.supports_branching').exception(
-                'branching resolver %r raised; treating as None', resolver,
-            )
+            logger.exception('branching resolver %r raised; treating as None', resolver)
             continue
         if result is not None:
             if not result:

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -152,6 +152,32 @@ def get_branchable_object_types():
     return ObjectType.objects.with_feature('branching')
 
 
+_branching_resolvers = []
+
+
+def register_branching_resolver(resolver):
+    """
+    Register a callable that determines branching support for a model.
+
+    Resolvers run after the explicit ``INCLUDE_MODELS`` check and before the
+    default ``ChangeLoggingMixin`` heuristic.  Used by plugins whose models
+    don't follow the standard NetBox change-logging mixin pattern but still
+    need to be routed to the active branch's schema — e.g. dynamically-
+    generated M2M through models that share a parent's branchable status
+    but are themselves plain ``models.Model`` subclasses.
+
+    Signature: ``resolver(model) -> bool | None``
+        True  — model is branchable, route to active branch
+        False — model is not branchable, route to main
+        None  — defer to next resolver / default heuristic
+
+    The first non-``None`` return wins.
+    """
+    if not callable(resolver):
+        raise TypeError("Branching resolver must be callable")
+    _branching_resolvers.append(resolver)
+
+
 def supports_branching(model):
     """
     Returns True if branching is supported for the given model; otherwise False.
@@ -166,19 +192,35 @@ def supports_branching(model):
     if label in INCLUDE_MODELS:
         return True
 
-    # RunPython data migrations receive historical models from the migration's
-    # StateApps. Those don't inherit ChangeLoggingMixin even when the live
-    # model does, so the issubclass() check would mis-classify them and the
-    # router would send branch-aware queries to main. Resolve to the live
-    # registry for an accurate class-hierarchy check.
-    try:
-        resolved_model = live_apps.get_model(model._meta.app_label, model._meta.model_name)
-    except LookupError:
-        resolved_model = model
+    # Plugin-registered resolvers — let plugins extend branching to their
+    # non-ChangeLoggingMixin models when appropriate.
+    for resolver in _branching_resolvers:
+        try:
+            result = resolver(model)
+        except Exception:
+            logging.getLogger('netbox_branching.utilities.supports_branching').exception(
+                'branching resolver %r raised; treating as None', resolver,
+            )
+            continue
+        if result is not None:
+            if not result:
+                return False
+            # True: still apply the exempt-models filter below.
+            break
+    else:
+        # RunPython data migrations receive historical models from the migration's
+        # StateApps. Those don't inherit ChangeLoggingMixin even when the live
+        # model does, so the issubclass() check would mis-classify them and the
+        # router would send branch-aware queries to main. Resolve to the live
+        # registry for an accurate class-hierarchy check.
+        try:
+            resolved_model = live_apps.get_model(model._meta.app_label, model._meta.model_name)
+        except LookupError:
+            resolved_model = model
 
-    # Exclude models which do not support change logging
-    if not issubclass(resolved_model, ChangeLoggingMixin):
-        return False
+        # Exclude models which do not support change logging
+        if not issubclass(resolved_model, ChangeLoggingMixin):
+            return False
 
     # TODO: Make this more efficient
     # Check for exempted models


### PR DESCRIPTION
### Fixes: netboxlabs/netbox-branching#545

Adds a public extension point register_branching_resolver() so plugins can opt their own models into branching support, parallel to the existing static INCLUDE_MODELS constant used for NetBox's built-in non-ChangeLoggingMixin models.