### PR TITLE
change last_updated to auto_now=True

### DIFF
--- a/netbox_branching/migrations/0009_changediff_last_updated_auto_now.py
+++ b/netbox_branching/migrations/0009_changediff_last_updated_auto_now.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_branching', '0008_branch_custom_permissions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='changediff',
+            name='last_updated',
+            field=models.DateTimeField(auto_now=True),
+        ),
+    ]

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -130,7 +130,7 @@ class ChangeDiff(models.Model):
         on_delete=models.CASCADE
     )
     last_updated = models.DateTimeField(
-        auto_now_add=True
+        auto_now=True
     )
     object_type = models.ForeignKey(
         to='contenttypes.ContentType',

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -155,7 +155,6 @@ def record_change_diff(instance, **kwargs):
         if diff := ChangeDiff.objects.filter(object_type=content_type, object_id=object_id, branch=branch).first():
             logger.debug(f"Updating branch change diff for change to {instance.changed_object}")
             diff.object = instance.changed_object
-            diff.last_updated = timezone.now()
             if diff.action != ObjectChangeActionChoices.ACTION_CREATE:
                 diff.action = instance.action
             diff.modified = instance.postchange_data_clean or None
@@ -204,7 +203,6 @@ def record_change_diff(instance, **kwargs):
                 original=instance.prechange_data_clean or None,
                 modified=instance.postchange_data_clean or None,
                 current=current_data or None,
-                last_updated=timezone.now(),
             )
             diff.save()
 

--- a/netbox_branching/tests/test_changediff.py
+++ b/netbox_branching/tests/test_changediff.py
@@ -1,9 +1,8 @@
 from datetime import timedelta
 
+from core.choices import ObjectChangeActionChoices
 from django.contrib.contenttypes.models import ContentType
 from django.test import SimpleTestCase, TestCase
-
-from core.choices import ObjectChangeActionChoices
 
 from netbox_branching.models import Branch, ChangeDiff
 

--- a/netbox_branching/tests/test_changediff.py
+++ b/netbox_branching/tests/test_changediff.py
@@ -1,6 +1,11 @@
-from django.test import SimpleTestCase
+from datetime import timedelta
 
-from netbox_branching.models import ChangeDiff
+from django.contrib.contenttypes.models import ContentType
+from django.test import SimpleTestCase, TestCase
+
+from core.choices import ObjectChangeActionChoices
+
+from netbox_branching.models import Branch, ChangeDiff
 
 DATA_A = {'name': 'foo', 'description': ''}
 DATA_B = {'name': 'foo', 'description': 'changed'}
@@ -130,3 +135,29 @@ class DiffPropertyTestCase(SimpleTestCase):
         self.assertEqual(result['original'], {'description': ''})
         self.assertEqual(result['modified'], {'description': 'changed'})
         self.assertEqual(result['current'], {'description': 'main change'})
+
+
+class LastUpdatedTestCase(TestCase):
+    """
+    Regression test for #483: last_updated must refresh on every save.
+    """
+
+    def test_last_updated_advances_on_save(self):
+        branch = Branch(name='Branch 1')
+        branch.save(provision=False)
+        diff = ChangeDiff.objects.create(
+            branch=branch,
+            object_type=ContentType.objects.get_for_model(Branch),
+            object_id=branch.pk,
+            action=ObjectChangeActionChoices.ACTION_CREATE,
+        )
+
+        # Back-date via .update() (bypasses auto_now) so save() has room to advance.
+        original = diff.last_updated - timedelta(hours=1)
+        ChangeDiff.objects.filter(pk=diff.pk).update(last_updated=original)
+        diff.refresh_from_db()
+        self.assertEqual(diff.last_updated, original)
+
+        diff.save()
+        diff.refresh_from_db()
+        self.assertGreater(diff.last_updated, original)


### PR DESCRIPTION
### Fixes: #483 

 ChangeDiff.last_updated was declared auto_now_add=True, so the timestamp was set only at row creation and never refreshed on subsequent saves - despite the field's name and its use as the default ordering key (ordering = ('-last_updated',)).

Flips the field to auto_now=True, adds the corresponding AlterField migration, and drops two now-redundant timezone.now() assignments at the Model.save() call sites in signal_receivers.py. The third site (line 136) uses QuerySet.update(), which bypasses auto_now, so its explicit assignment is left in place.

Existing rows keep their old last_updated until the next save (AlterField does not backfill); this is intentional.

Adds a regression test that back-dates last_updated via .update() and asserts the next save() advances it.
