### PR TITLE
#554 update help text for branch merging

### DIFF
--- a/netbox_branching/forms/misc.py
+++ b/netbox_branching/forms/misc.py
@@ -73,6 +73,17 @@ class BranchSyncForm(BaseBranchActionForm):
 
 class BranchMergeForm(BaseBranchActionForm):
     """Form for merging a branch."""
+    commit = forms.BooleanField(
+        required=False,
+        label=_('Commit changes'),
+        help_text=_(
+            '<ul class="mb-0 ps-3">'
+            '<li>If checked, the merge is committed and the branch remains available for revert or archival.</li>'
+            '<li>If unchecked, the operation is rolled back after completion and no changes are saved '
+            '(dry run).</li>'
+            '</ul>'
+        )
+    )
     merge_strategy = forms.ChoiceField(
         choices=BranchMergeStrategyChoices,
         initial=BranchMergeStrategyChoices.ITERATIVE,
@@ -88,16 +99,6 @@ class BranchMergeForm(BaseBranchActionForm):
             ),
         })
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields['commit'].help_text = _(
-            '<ul class="mb-0 ps-3">'
-            '<li>If checked, the merge is committed and the branch remains available for revert or archival.</li>'
-            '<li>If unchecked, the operation is rolled back after completion and no changes are saved '
-            '(dry run).</li>'
-            '</ul>'
-        )
 
 
 class BranchRevertForm(BaseBranchActionForm):

--- a/netbox_branching/forms/misc.py
+++ b/netbox_branching/forms/misc.py
@@ -18,7 +18,6 @@ __all__ = (
 class DescriptiveRadioSelect(forms.RadioSelect):
     """Radio select widget that renders a short description beneath each choice."""
     template_name = 'netbox_branching/widgets/radio_select.html'
-    option_template_name = 'netbox_branching/widgets/radio_option.html'
 
     def __init__(self, *args, descriptions=None, **kwargs):
         self.descriptions = descriptions or {}

--- a/netbox_branching/forms/misc.py
+++ b/netbox_branching/forms/misc.py
@@ -10,8 +10,24 @@ __all__ = (
     'BranchSyncForm',
     'BulkMigrateBranchForm',
     'ConfirmationForm',
+    'DescriptiveRadioSelect',
     'MigrateBranchForm',
 )
+
+
+class DescriptiveRadioSelect(forms.RadioSelect):
+    """Radio select widget that renders a short description beneath each choice."""
+    template_name = 'netbox_branching/widgets/radio_select.html'
+    option_template_name = 'netbox_branching/widgets/radio_option.html'
+
+    def __init__(self, *args, descriptions=None, **kwargs):
+        self.descriptions = descriptions or {}
+        super().__init__(*args, **kwargs)
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
+        option['description'] = self.descriptions.get(str(value), '')
+        return option
 
 
 class BaseBranchActionForm(forms.Form):
@@ -24,7 +40,9 @@ class BaseBranchActionForm(forms.Form):
     commit = forms.BooleanField(
         required=False,
         label=_('Commit changes'),
-        help_text=_('Leave unchecked to perform a dry run')
+        help_text=_(
+            'If unchecked, the operation is rolled back after completion and no changes are saved (dry run).'
+        )
     )
 
     def __init__(self, branch, *args, allow_commit=True, **kwargs):
@@ -60,8 +78,26 @@ class BranchMergeForm(BaseBranchActionForm):
         initial=BranchMergeStrategyChoices.ITERATIVE,
         required=True,
         label=_('Merge Strategy'),
-        help_text=_('Strategy to use when merging changes.')
+        widget=DescriptiveRadioSelect(descriptions={
+            BranchMergeStrategyChoices.ITERATIVE: _(
+                'Replay each change individually in order, preserving the full audit trail.'
+            ),
+            BranchMergeStrategyChoices.SQUASH: _(
+                'Collapse all changes per object into a single create, update, or delete. Can resolve some '
+                'merge cases that the iterative strategy cannot.'
+            ),
+        })
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['commit'].help_text = _(
+            '<ul class="mb-0 ps-3">'
+            '<li>If checked, the merge is committed and the branch remains available for revert or archival.</li>'
+            '<li>If unchecked, the operation is rolled back after completion and no changes are saved '
+            '(dry run).</li>'
+            '</ul>'
+        )
 
 
 class BranchRevertForm(BaseBranchActionForm):

--- a/netbox_branching/templates/netbox_branching/widgets/radio_select.html
+++ b/netbox_branching/templates/netbox_branching/widgets/radio_select.html
@@ -1,0 +1,7 @@
+{% for group, options, index in widget.optgroups %}{% for option in options %}<div class="form-check mb-2">
+  <input type="{{ option.type }}" name="{{ option.name }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" with widget=option %} class="form-check-input">
+  <label{% if option.attrs.id %} for="{{ option.attrs.id }}"{% endif %} class="form-check-label">
+    {{ option.label }}
+  </label>
+  {% if option.description %}<div class="form-text">{{ option.description }}</div>{% endif %}
+</div>{% endfor %}{% endfor %}


### PR DESCRIPTION
### Fixes: netboxlabs/netbox-branching#554

Adds extra help text to the form explaining what the different strategies do and what the commit changes box does in more detail.

<img src="https://github.com/user-attachments/assets/71e580d4-fab4-45e5-baff-784e2efe0c7d " alt="Monosnap Merge Branch b1 | NetBox 2026-05-13 14-03-09" width="1438" data-linear-height="673" />