### PR TITLE
#445 fix branch edit/save race condition for merge status

### DIFF
--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -288,17 +288,45 @@ class Branch(JobsMixin, PrimaryModel):
                     ).format(max=max_working_branches)
                 )
 
-    def save(self, provision=True, *args, **kwargs):
+    # Fields written by background jobs (provision/sync/migrate/merge/revert) via
+    # `Branch.objects.filter(...).update(...)`. On a normal save these columns are
+    # excluded from the UPDATE statement so a stale in-memory instance (e.g. one
+    # loaded into a form or DRF serializer before a job ran) cannot clobber a
+    # concurrent lifecycle update. Internal callers that legitimately need to write
+    # these fields opt in by passing `update_merge_sync_fields=True`.
+    LIFECYCLE_FIELDS = (
+        'status', 'last_sync', 'merged_time', 'merged_by', 'applied_migrations',
+    )
+
+    def save(self, provision=True, update_merge_sync_fields=False, *args, **kwargs):
         """
         Args:
             provision: If True, automatically enqueue a background Job to provision the Branch. (Set this
                        to False if you will call provision() on the instance manually.)
+            update_merge_sync_fields: If True, the caller intends to write lifecycle fields and the
+                       pre-save exclusion is skipped. Used by internal lifecycle methods
+                       (sync/migrate/merge/revert).
         """
         from netbox_branching.jobs import ProvisionBranchJob
 
         _provision = provision and self.pk is None
+        _shield_lifecycle = (
+            self.pk and not update_merge_sync_fields and not kwargs.get('update_fields')
+        )
+
+        if _shield_lifecycle:
+            kwargs['update_fields'] = [
+                f.name for f in self._meta.concrete_fields
+                if f.name not in self.LIFECYCLE_FIELDS and not f.primary_key
+            ]
 
         super().save(*args, **kwargs)
+
+        if _shield_lifecycle:
+            # The UPDATE skipped the lifecycle columns, so the in-memory instance still holds the
+            # pre-save (potentially stale) values. Pull them back from the DB so callers — and DRF
+            # response serializers in particular — see current state.
+            self.refresh_from_db(fields=self.LIFECYCLE_FIELDS)
 
         if _provision:
             # Enqueue a background job to provision the Branch
@@ -312,10 +340,12 @@ class Branch(JobsMixin, PrimaryModel):
         if active_branch.get() == self:
             raise AbortRequest(_("The active branch cannot be deleted."))
 
-        # Deprovision the schema
+        # Delete the row first so a blocked deletion (e.g. a Branch in a transitional
+        # state, rejected by the pre_delete receiver) does not drop the schema.
+        result = super().delete(*args, **kwargs)
         self.deprovision()
 
-        return super().delete(*args, **kwargs)
+        return result
 
     @staticmethod
     def _generate_schema_id(length=8):
@@ -659,7 +689,7 @@ class Branch(JobsMixin, PrimaryModel):
         logger.debug(f"Setting branch status to {BranchStatusChoices.READY}")
         self.last_sync = timezone.now()
         self.status = BranchStatusChoices.READY
-        self.save()
+        self.save(update_merge_sync_fields=True)
 
         # Record a branch event for the sync
         logger.debug(f"Recording branch event: {BranchEventTypeChoices.SYNCED}")
@@ -738,7 +768,7 @@ class Branch(JobsMixin, PrimaryModel):
         # Reset Branch status to ready
         logger.debug(f"Setting branch status to {BranchStatusChoices.READY}")
         self.status = BranchStatusChoices.READY
-        self.save()
+        self.save(update_merge_sync_fields=True)
 
         # Record a branch event for the migration
         logger.debug(f"Recording branch event: {BranchEventTypeChoices.MIGRATED}")
@@ -808,7 +838,7 @@ class Branch(JobsMixin, PrimaryModel):
         self.status = BranchStatusChoices.MERGED
         self.merged_time = timezone.now()
         self.merged_by = user
-        self.save()
+        self.save(update_merge_sync_fields=True)
 
         # Record a branch event for the merge
         logger.debug(f"Recording branch event: {BranchEventTypeChoices.MERGED}")
@@ -884,7 +914,7 @@ class Branch(JobsMixin, PrimaryModel):
         self.merged_time = None
         self.merged_by = None
         self.merge_strategy = None
-        self.save()
+        self.save(update_merge_sync_fields=True)
 
         # Record a branch event for the merge
         logger.debug(f"Recording branch event: {BranchEventTypeChoices.REVERTED}")

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -340,10 +340,14 @@ class Branch(JobsMixin, PrimaryModel):
         if active_branch.get() == self:
             raise AbortRequest(_("The active branch cannot be deleted."))
 
-        # Delete the row first so a blocked deletion (e.g. a Branch in a transitional
-        # state, rejected by the pre_delete receiver) does not drop the schema.
-        result = super().delete(*args, **kwargs)
-        self.deprovision()
+        # Delete the row before dropping the schema so a blocked deletion (e.g. a Branch
+        # in a transitional state, rejected by the pre_delete receiver) does not strand
+        # the schema. The atomic block ensures that if deprovision() fails after the row
+        # is deleted, the row delete is rolled back too — PostgreSQL DDL (DROP SCHEMA) is
+        # transactional, so neither side is left orphaned.
+        with transaction.atomic():
+            result = super().delete(*args, **kwargs)
+            self.deprovision()
 
         return result
 
@@ -1095,12 +1099,12 @@ class Branch(JobsMixin, PrimaryModel):
         if not self.can_archive:
             raise Exception("Archiving this branch is not permitted.")
 
-        # Deprovision the branch's schema
-        self.deprovision()
-
-        # Update the branch's status to "archived"
-        Branch.objects.filter(pk=self.pk).update(status=BranchStatusChoices.ARCHIVED)
-        BranchEvent.objects.create(branch=self, user=user, type=BranchEventTypeChoices.ARCHIVED)
+        # Drop the schema and flip the status atomically so a failure after the schema
+        # has been dropped does not leave an un-archived Branch with no schema.
+        with transaction.atomic():
+            self.deprovision()
+            Branch.objects.filter(pk=self.pk).update(status=BranchStatusChoices.ARCHIVED)
+            BranchEvent.objects.create(branch=self, user=user, type=BranchEventTypeChoices.ARCHIVED)
 
     archive.alters_data = True
 

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -288,12 +288,7 @@ class Branch(JobsMixin, PrimaryModel):
                     ).format(max=max_working_branches)
                 )
 
-    # Fields written by background jobs (provision/sync/migrate/merge/revert) via
-    # `Branch.objects.filter(...).update(...)`. On a normal save these columns are
-    # excluded from the UPDATE statement so a stale in-memory instance (e.g. one
-    # loaded into a form or DRF serializer before a job ran) cannot clobber a
-    # concurrent lifecycle update. Internal callers that legitimately need to write
-    # these fields opt in by passing `update_merge_sync_fields=True`.
+    # Fields owned by background jobs; excluded from save() by default to avoid clobbering. See #445.
     LIFECYCLE_FIELDS = (
         'status', 'last_sync', 'merged_time', 'merged_by', 'applied_migrations',
     )
@@ -311,7 +306,7 @@ class Branch(JobsMixin, PrimaryModel):
 
         _provision = provision and self.pk is None
         _shield_lifecycle = (
-            self.pk and not update_merge_sync_fields and not kwargs.get('update_fields')
+            self.pk and not update_merge_sync_fields and 'update_fields' not in kwargs
         )
 
         if _shield_lifecycle:
@@ -323,9 +318,7 @@ class Branch(JobsMixin, PrimaryModel):
         super().save(*args, **kwargs)
 
         if _shield_lifecycle:
-            # The UPDATE skipped the lifecycle columns, so the in-memory instance still holds the
-            # pre-save (potentially stale) values. Pull them back from the DB so callers — and DRF
-            # response serializers in particular — see current state.
+            # Refresh excluded fields so callers (notably DRF response serializers) see current state.
             self.refresh_from_db(fields=self.LIFECYCLE_FIELDS)
 
         if _provision:
@@ -340,11 +333,7 @@ class Branch(JobsMixin, PrimaryModel):
         if active_branch.get() == self:
             raise AbortRequest(_("The active branch cannot be deleted."))
 
-        # Delete the row before dropping the schema so a blocked deletion (e.g. a Branch
-        # in a transitional state, rejected by the pre_delete receiver) does not strand
-        # the schema. The atomic block ensures that if deprovision() fails after the row
-        # is deleted, the row delete is rolled back too — PostgreSQL DDL (DROP SCHEMA) is
-        # transactional, so neither side is left orphaned.
+        # Row delete and schema drop must succeed or fail together — see #445.
         with transaction.atomic():
             result = super().delete(*args, **kwargs)
             self.deprovision()

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -7,9 +7,11 @@ from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
 from extras.validators import CustomValidator
 from netbox.plugins import get_plugin_config
+from utilities.exceptions import AbortRequest
 
 from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.constants import SKIP_INDEXES
+from netbox_branching.forms import BranchForm
 from netbox_branching.models import Branch
 from netbox_branching.utilities import get_tables_to_replicate
 
@@ -176,12 +178,12 @@ class BranchTestCase(TransactionTestCase):
 
         # Set creation time to 9 days in the past
         branch.last_sync = timezone.now() - timedelta(days=9)
-        branch.save()
+        branch.save(update_merge_sync_fields=True)
         self.assertFalse(branch.is_stale)
 
         # Set creation time to 11 days in the past
         branch.last_sync = timezone.now() - timedelta(days=11)
-        branch.save()
+        branch.save(update_merge_sync_fields=True)
         self.assertTrue(branch.is_stale)
 
     @override_settings(CHANGELOG_RETENTION=10)
@@ -191,17 +193,17 @@ class BranchTestCase(TransactionTestCase):
 
         # Not yet in warning window (2 days ago, 8 days remaining > 7-day default threshold)
         branch.last_sync = timezone.now() - timedelta(days=2)
-        branch.save()
+        branch.save(update_merge_sync_fields=True)
         self.assertIsNone(branch.stale_warning)
 
         # Within warning window (4 days ago, 6 days remaining <= 7-day default threshold)
         branch.last_sync = timezone.now() - timedelta(days=4)
-        branch.save()
+        branch.save(update_merge_sync_fields=True)
         self.assertEqual(branch.stale_warning, 6)
 
         # Already stale (11 days ago) — warning should not show
         branch.last_sync = timezone.now() - timedelta(days=11)
-        branch.save()
+        branch.save(update_merge_sync_fields=True)
         self.assertIsNone(branch.stale_warning)
 
     @override_settings(CHANGELOG_RETENTION=7)
@@ -211,5 +213,66 @@ class BranchTestCase(TransactionTestCase):
         branch.save(provision=False)
 
         branch.last_sync = timezone.now() - timedelta(days=6)
-        branch.save()
+        branch.save(update_merge_sync_fields=True)
         self.assertEqual(branch.stale_warning, 1)
+
+    def test_edit_form_preserves_lifecycle_fields(self):
+        """
+        Regression test for issue #445: editing a Branch through the form must not
+        overwrite lifecycle fields (status, last_sync, etc.) that may have been
+        updated by a background job after the form's instance was loaded.
+        """
+        branch = Branch(name='Branch 1')
+        branch.save(provision=False)
+
+        # Simulate a form instance loaded while status was still NEW
+        stale_instance = Branch.objects.get(pk=branch.pk)
+        self.assertEqual(stale_instance.status, BranchStatusChoices.NEW)
+
+        # Concurrently, a background job updates lifecycle state
+        sync_time = timezone.now() - timedelta(minutes=1)
+        Branch.objects.filter(pk=branch.pk).update(
+            status=BranchStatusChoices.READY,
+            last_sync=sync_time,
+        )
+
+        # The user submits the edit form against the stale instance
+        form = BranchForm(
+            data={'name': 'Renamed Branch', 'description': '', 'comments': ''},
+            instance=stale_instance,
+        )
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        form.save()
+
+        # The name change persisted, lifecycle fields were not clobbered
+        updated = Branch.objects.get(pk=branch.pk)
+        self.assertEqual(updated.name, 'Renamed Branch')
+        self.assertEqual(updated.status, BranchStatusChoices.READY)
+        self.assertEqual(updated.last_sync, sync_time)
+
+    def test_delete_transitional_branch_preserves_schema(self):
+        """
+        Regression test for issue #445: a delete attempt against a Branch in a
+        transitional state must be blocked AND must not deprovision the schema.
+        """
+        branch = Branch(name='Branch 1')
+        branch.save(provision=False)
+        branch.provision(user=None)
+
+        # Move the branch into a transitional state, as a background job would
+        Branch.objects.filter(pk=branch.pk).update(status=BranchStatusChoices.PROVISIONING)
+        branch.refresh_from_db()
+
+        with self.assertRaises(AbortRequest):
+            branch.delete()
+
+        # The branch row must still exist
+        self.assertTrue(Branch.objects.filter(pk=branch.pk).exists())
+
+        # The schema must still exist
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT schema_name FROM information_schema.schemata WHERE schema_name=%s",
+                [branch.schema_name]
+            )
+            self.assertIsNotNone(cursor.fetchone(), msg="Schema was unexpectedly dropped on blocked delete")

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -13,6 +13,7 @@ from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.constants import SKIP_INDEXES
 from netbox_branching.forms import BranchForm
 from netbox_branching.models import Branch
+from netbox_branching.signals import pre_deprovision
 from netbox_branching.utilities import get_tables_to_replicate
 
 from .utils import fetchall, fetchone
@@ -276,3 +277,34 @@ class BranchTestCase(TransactionTestCase):
                 [branch.schema_name]
             )
             self.assertIsNotNone(cursor.fetchone(), msg="Schema was unexpectedly dropped on blocked delete")
+
+    def test_delete_rolls_back_when_deprovision_fails(self):
+        """
+        If deprovision() raises after super().delete() has already removed the row,
+        the atomic block must roll back the row delete and the schema drop together,
+        leaving both the Branch row and its schema intact.
+        """
+        branch = Branch(name='Branch 1')
+        branch.save(provision=False)
+        branch.provision(user=None)
+
+        def boom(sender, **kwargs):
+            raise RuntimeError("simulated deprovision failure")
+
+        pre_deprovision.connect(boom, sender=Branch, weak=False)
+        try:
+            with self.assertRaises(RuntimeError):
+                branch.delete()
+        finally:
+            pre_deprovision.disconnect(boom, sender=Branch)
+
+        # The branch row must still exist (atomic rolled back the super().delete())
+        self.assertTrue(Branch.objects.filter(pk=branch.pk).exists())
+
+        # The schema must still exist (DROP SCHEMA never executed)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT schema_name FROM information_schema.schemata WHERE schema_name=%s",
+                [branch.schema_name]
+            )
+            self.assertIsNotNone(cursor.fetchone(), msg="Schema was unexpectedly dropped despite failed deprovision")

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -288,6 +288,11 @@ class BranchTestCase(TransactionTestCase):
         branch.save(provision=False)
         branch.provision(user=None)
 
+        # Capture identifiers up front — Django's Collector sets instance.pk to None
+        # after running the DELETE, and that mutation is not undone by a rollback.
+        branch_pk = branch.pk
+        schema_name = branch.schema_name
+
         def boom(sender, **kwargs):
             raise RuntimeError("simulated deprovision failure")
 
@@ -299,12 +304,12 @@ class BranchTestCase(TransactionTestCase):
             pre_deprovision.disconnect(boom, sender=Branch)
 
         # The branch row must still exist (atomic rolled back the super().delete())
-        self.assertTrue(Branch.objects.filter(pk=branch.pk).exists())
+        self.assertTrue(Branch.objects.filter(pk=branch_pk).exists())
 
         # The schema must still exist (DROP SCHEMA never executed)
         with connection.cursor() as cursor:
             cursor.execute(
                 "SELECT schema_name FROM information_schema.schemata WHERE schema_name=%s",
-                [branch.schema_name]
+                [schema_name]
             )
             self.assertIsNotNone(cursor.fetchone(), msg="Schema was unexpectedly dropped despite failed deprovision")

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -13,7 +13,7 @@ from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.constants import SKIP_INDEXES
 from netbox_branching.forms import BranchForm
 from netbox_branching.models import Branch
-from netbox_branching.signals import pre_deprovision
+from netbox_branching.signals import post_deprovision, pre_deprovision
 from netbox_branching.utilities import get_tables_to_replicate
 
 from .utils import fetchall, fetchone
@@ -278,18 +278,26 @@ class BranchTestCase(TransactionTestCase):
             )
             self.assertIsNotNone(cursor.fetchone(), msg="Schema was unexpectedly dropped on blocked delete")
 
-    def test_delete_rolls_back_when_deprovision_fails(self):
+    def _assert_branch_and_schema_intact(self, branch_pk, schema_name):
+        self.assertTrue(Branch.objects.filter(pk=branch_pk).exists())
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT schema_name FROM information_schema.schemata WHERE schema_name=%s",
+                [schema_name]
+            )
+            self.assertIsNotNone(cursor.fetchone(), msg="Schema unexpectedly missing")
+
+    def test_delete_rolls_back_row_when_deprovision_raises(self):
         """
-        If deprovision() raises after super().delete() has already removed the row,
-        the atomic block must roll back the row delete and the schema drop together,
-        leaving both the Branch row and its schema intact.
+        A failure raised inside deprovision() (before DROP SCHEMA runs) must roll back
+        the row delete that super().delete() already performed, leaving both intact.
         """
         branch = Branch(name='Branch 1')
         branch.save(provision=False)
         branch.provision(user=None)
 
-        # Capture identifiers up front — Django's Collector sets instance.pk to None
-        # after running the DELETE, and that mutation is not undone by a rollback.
+        # Capture identifiers up front: Django's Collector sets instance.pk to None
+        # after running the DELETE, and that mutation is not undone by rollback.
         branch_pk = branch.pk
         schema_name = branch.schema_name
 
@@ -303,13 +311,29 @@ class BranchTestCase(TransactionTestCase):
         finally:
             pre_deprovision.disconnect(boom, sender=Branch)
 
-        # The branch row must still exist (atomic rolled back the super().delete())
-        self.assertTrue(Branch.objects.filter(pk=branch_pk).exists())
+        self._assert_branch_and_schema_intact(branch_pk, schema_name)
 
-        # The schema must still exist (DROP SCHEMA never executed)
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT schema_name FROM information_schema.schemata WHERE schema_name=%s",
-                [schema_name]
-            )
-            self.assertIsNotNone(cursor.fetchone(), msg="Schema was unexpectedly dropped despite failed deprovision")
+    def test_delete_rolls_back_schema_drop_when_failure_follows(self):
+        """
+        If a failure is raised after DROP SCHEMA has already executed, the atomic
+        block must roll back the DDL too — verifying the PostgreSQL DDL-is-transactional
+        property the fix relies on.
+        """
+        branch = Branch(name='Branch 1')
+        branch.save(provision=False)
+        branch.provision(user=None)
+
+        branch_pk = branch.pk
+        schema_name = branch.schema_name
+
+        def boom(sender, **kwargs):
+            raise RuntimeError("simulated post-drop failure")
+
+        post_deprovision.connect(boom, sender=Branch, weak=False)
+        try:
+            with self.assertRaises(RuntimeError):
+                branch.delete()
+        finally:
+            post_deprovision.disconnect(boom, sender=Branch)
+
+        self._assert_branch_and_schema_intact(branch_pk, schema_name)

--- a/netbox_branching/tests/test_request.py
+++ b/netbox_branching/tests/test_request.py
@@ -94,7 +94,7 @@ class RequestTestCase(TestCase):
         """
         branch = Branch.objects.first()
         branch.status = BranchStatusChoices.ARCHIVED
-        branch.save(provision=False)
+        branch.save(provision=False, update_merge_sync_fields=True)
 
         self.client.cookies.load({
             COOKIE_NAME: branch.schema_id,


### PR DESCRIPTION
### Fixes: #445 

A Branch can become permanently stuck in provisioning (or any transitional state) when a user edits it via the UI or REST API while a background job is updating the merge status and related fields.

Background jobs update status / last_sync / merged_time / merged_by / applied_migrations via Branch.objects.filter(pk=...).update(...), which never touches in-memory instances. A form or DRF serializer that loaded a Branch before the job ran would, on save(), write all fields back from its stale instance — clobbering the job's update.

**Fix:**
- Branch.save() now excludes the lifecycle fields from the UPDATE statement by default (via computed update_fields), then refreshes them from the DB into the instance so callers see current state. Internal lifecycle methods (sync, migrate, merge, revert) opt out with update_merge_sync_fields=True to write those fields intentionally.
- Branch.delete() reorders so super().delete() runs first; this prevents deprovision() from dropping the schema when the pre_delete receiver aborts the deletion (e.g. a Branch in a transitional state).