### PR TITLE
#564 - Clarify no conflicts found UI

### DIFF
--- a/netbox_branching/templates/netbox_branching/branch.html
+++ b/netbox_branching/templates/netbox_branching/branch.html
@@ -156,8 +156,11 @@
               {% else %}
                 <span class="text-green">
                   <i class="mdi mdi-check-bold"></i>
-                  {% trans "None found" %}
+                  {% trans "No field-level conflicts found" %}
                 </span>
+                <div class="small text-muted">
+                  {% trans "Note: Database constraint violations (e.g. duplicate names or slugs) can only be detected during merge." %}
+                </div>
               {% endif %}
             </td>
           </tr>

--- a/netbox_branching/templates/netbox_branching/branch_action.html
+++ b/netbox_branching/templates/netbox_branching/branch_action.html
@@ -36,7 +36,8 @@
     {% else %}
       <div class="alert alert-success">
         <i class="mdi mdi-check-circle"></i>
-        {% trans "No conflicts found." %}
+        {% trans "No field-level conflicts found." %}
+        {% trans "(Note: Database constraint violations, e.g. duplicate names or slugs, can only be detected during merge.)" %}
       </div>
     {% endif %}
     {% if changes_summary.creates or changes_summary.updates or changes_summary.deletes %}

--- a/netbox_branching/templates/netbox_branching/branch_action.html
+++ b/netbox_branching/templates/netbox_branching/branch_action.html
@@ -36,8 +36,7 @@
     {% else %}
       <div class="alert alert-success">
         <i class="mdi mdi-check-circle"></i>
-        {% trans "No field-level conflicts found." %}
-        {% trans "(Note: Database constraint violations, e.g. duplicate names or slugs, can only be detected during merge.)" %}
+        {% blocktrans %}No field-level conflicts found. (Note: Database constraint violations, e.g. duplicate names or slugs, can only be detected during merge.){% endblocktrans %}
       </div>
     {% endif %}
     {% if changes_summary.creates or changes_summary.updates or changes_summary.deletes %}


### PR DESCRIPTION
### Fixes: #564 

Shows clarification on both merge page and branch detail page when showing conflicts.

<img width="806" height="647" alt="Monosnap bx | NetBox 2026-05-18 11-36-40" src="https://github.com/user-attachments/assets/2bf2a1f4-a822-44b4-bf2f-bf57c90582a8" />
<img width="1158" height="167" alt="Monosnap Merge Branch bx | NetBox 2026-05-18 11-36-18" src="https://github.com/user-attachments/assets/28c4ff97-b101-4a28-be59-bb307ab7932d" />
