### PR TITLE
#568 - fix object modified warning for merged branch

### DIFF
--- a/netbox_branching/template_content.py
+++ b/netbox_branching/template_content.py
@@ -42,7 +42,7 @@ class BranchNotification(PluginTemplateExtension):
             object_type=ct,
             object_id=instance.pk
         ).exclude(
-            branch__status=BranchStatusChoices.MERGED
+            branch__status__in=(BranchStatusChoices.MERGED, BranchStatusChoices.ARCHIVED)
         ).exclude(
             branch=active_branch.get()
         )


### PR DESCRIPTION
### Fixes: #568 

Don't display object modified warning message if branch is archived.
