### PR TITLE
#28 - Preserve sync conflict resolution when merging branch

### DIFF
--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -566,18 +566,22 @@ class Branch(JobsMixin, PrimaryModel):
     # Branch actions
     #
 
-    def _apply_sync_update(self, change, user, logger, request_id, touched_object_keys):
+    def _apply_sync_update(self, change, logger, touched_object_keys, sync_buffer):
         """
         Apply a non-DELETE change from main and, when the branch has also touched the
-        same object, record a sync-originated ObjectChange so the merge replay does
-        not undo it (#28).
+        same object, buffer the pre/post state so a single synthetic ObjectChange can
+        be written per object after the sync loop completes (#28).
 
         ``touched_object_keys`` is a set of ``(content_type_id, object_id)`` tuples
         for which the branch has at least one ChangeDiff. It is pre-fetched once by
         the caller to avoid an N+1 query inside the sync loop.
 
-        Sequential main changes to the same object produce one synthetic per change;
-        merge replay applies them in order and lands on main's final value.
+        ``sync_buffer`` is a dict keyed by ``(content_type_id, object_id)``. Sequential
+        main changes to the same object collapse into a single buffered entry: the
+        first prechange is preserved and postchange is overwritten on each hit. Both
+        merge strategies replay to the same end state with or without this
+        consolidation, so dropping the intermediate synthetic rows is a no-op for
+        correctness while reducing ChangeDiff write traffic at flush time.
         """
         content_type_id = change.changed_object_type_id
         object_id = change.changed_object_id
@@ -588,6 +592,7 @@ class Branch(JobsMixin, PrimaryModel):
             return
 
         model_class = change.changed_object_type.model_class()
+        key = (content_type_id, object_id)
 
         # Capture the branch's state before applying main's change
         try:
@@ -605,32 +610,74 @@ class Branch(JobsMixin, PrimaryModel):
         try:
             after = model_class.objects.using(self.connection_name).get(pk=object_id)
         except model_class.DoesNotExist:
+            # Apply turned this into a delete (shouldn't happen for non-DELETE actions,
+            # but be defensive). Drop any prior buffered entry for this object.
+            sync_buffer.pop(key, None)
             return
         postchange_data = _serialize_for_sync(after)
-        if prechange_data == postchange_data:
+
+        if key in sync_buffer:
+            # Consolidate: preserve the original prechange, overwrite postchange.
+            entry = sync_buffer[key]
+            entry['postchange_data'] = postchange_data
+            entry['object_repr'] = str(after)
+            if change.user_name and change.user_name not in entry['user_names']:
+                entry['user_names'].append(change.user_name)
+        else:
+            sync_buffer[key] = {
+                'content_type_id': content_type_id,
+                'object_id': object_id,
+                'model_class': model_class,
+                'object_repr': str(after),
+                'prechange_data': prechange_data,
+                'postchange_data': postchange_data,
+                'user_names': [change.user_name] if change.user_name else [],
+            }
+
+    def _flush_sync_buffer(self, sync_buffer, user, request_id, logger):
+        """
+        Write the consolidated synthetic ObjectChanges from the sync loop to the
+        branch schema. Each save fires record_change_diff, which updates ChangeDiff
+        on the default DB — keeping these writes batched at the end of sync
+        confines the ChangeDiff row locks to a brief flush window instead of
+        holding them across the entire sync loop.
+
+        ``record_change_diff`` is registered on the core ObjectChange model, so
+        rows must be created via ``ObjectChange_`` rather than the branch-aware
+        proxy (Django dispatches proxy post_save with the proxy as sender).
+        """
+        if not sync_buffer:
             return
 
-        # Create via the core model, not the proxy: Django dispatches proxy post_save
-        # with the proxy as sender, which would bypass record_change_diff.
-        sync_message = (
-            f'Synced from main (originally by {change.user_name or "system"})'
-        )[:_OBJECTCHANGE_MESSAGE_MAX_LENGTH]
-        ObjectChange_.objects.using(self.connection_name).create(
-            action=ObjectChangeActionChoices.ACTION_UPDATE,
-            changed_object_type_id=content_type_id,
-            changed_object_id=object_id,
-            object_repr=str(after),
-            prechange_data=prechange_data,
-            postchange_data=postchange_data,
-            user=user,
-            user_name=user.username if user else '',
-            request_id=request_id,
-            message=sync_message,
-        )
-        logger.debug(
-            f'Recorded sync-applied change to {model_class._meta.verbose_name} {after} '
-            f'(supersedes prior branch change on conflicting fields)'
-        )
+        user_name = user.username if user else ''
+
+        for entry in sync_buffer.values():
+            # Drop entries whose consolidated net change is a no-op (e.g. main
+            # toggled a value and then toggled it back during this sync window).
+            if entry['prechange_data'] == entry['postchange_data']:
+                continue
+
+            originals = ', '.join(entry['user_names']) or 'system'
+            sync_message = (
+                f'Synced from main (originally by {originals})'
+            )[:_OBJECTCHANGE_MESSAGE_MAX_LENGTH]
+
+            ObjectChange_.objects.using(self.connection_name).create(
+                action=ObjectChangeActionChoices.ACTION_UPDATE,
+                changed_object_type_id=entry['content_type_id'],
+                changed_object_id=entry['object_id'],
+                object_repr=entry['object_repr'],
+                prechange_data=entry['prechange_data'],
+                postchange_data=entry['postchange_data'],
+                user=user,
+                user_name=user_name,
+                request_id=request_id,
+                message=sync_message,
+            )
+            logger.debug(
+                f'Recorded sync-applied change to {entry["model_class"]._meta.verbose_name} '
+                f'{entry["object_repr"]} (supersedes prior branch change on conflicting fields)'
+            )
 
     def _handle_sync_delete(self, change, branchable_models, user, logger, request_id=None):
         """
@@ -731,10 +778,12 @@ class Branch(JobsMixin, PrimaryModel):
         request_id = uuid.uuid4()
 
         try:
-            # Wrap both the default DB and the branch schema in atomic blocks so that
-            # ChangeDiff updates (written to the default DB via record_change_diff
-            # when the synthetic ObjectChange is saved) roll back together with the
-            # branch-schema writes if AbortTransaction is raised (e.g. commit=False).
+            # The outer DEFAULT_DB_ALIAS atomic exists so that ChangeDiff updates
+            # (written via record_change_diff when synthetic ObjectChanges are saved
+            # during _flush_sync_buffer) roll back together with the branch-schema
+            # writes if AbortTransaction is raised (e.g. commit=False). It costs
+            # essentially nothing during the loop itself: no main-DB writes happen
+            # until the flush, so no row locks are held on the default DB until then.
             with (
                 activate_branch(self),
                 transaction.atomic(using=DEFAULT_DB_ALIAS),
@@ -751,6 +800,11 @@ class Branch(JobsMixin, PrimaryModel):
                     ChangeDiff.objects.filter(branch=self).values_list('object_type_id', 'object_id')
                 )
 
+                # Buffer synthetic ObjectChange writes during the loop and flush in
+                # one batch at the end. Keyed by (content_type_id, object_id) so
+                # multiple main updates to the same object collapse to one entry.
+                sync_buffer = {}
+
                 # Apply each change from the main schema
                 for change in changes:
                     model_class = change.changed_object_type.model_class()
@@ -760,8 +814,16 @@ class Branch(JobsMixin, PrimaryModel):
                             change, branchable_models, user, logger, request_id=request_id
                         )
                         models.update(cascade_models)
+                        # A buffered synthetic UPDATE is invalidated by a later DELETE.
+                        sync_buffer.pop(
+                            (change.changed_object_type_id, change.changed_object_id), None
+                        )
                     else:
-                        self._apply_sync_update(change, user, logger, request_id, touched_object_keys)
+                        self._apply_sync_update(change, logger, touched_object_keys, sync_buffer)
+
+                # Flush buffered synthetic ObjectChanges. This is where
+                # record_change_diff actually fires and writes to the default DB.
+                self._flush_sync_buffer(sync_buffer, user, request_id, logger)
 
                 if not commit:
                     raise AbortTransaction()

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -51,7 +51,7 @@ from netbox_branching.utilities import (
     supports_branching,
 )
 
-from .changes import ObjectChange
+from .changes import ChangeDiff, ObjectChange
 
 __all__ = (
     'Branch',
@@ -575,6 +575,9 @@ class Branch(JobsMixin, PrimaryModel):
         ``touched_object_keys`` is a set of ``(content_type_id, object_id)`` tuples
         for which the branch has at least one ChangeDiff. It is pre-fetched once by
         the caller to avoid an N+1 query inside the sync loop.
+
+        Sequential main changes to the same object produce one synthetic per change;
+        merge replay applies them in order and lands on main's final value.
         """
         content_type_id = change.changed_object_type_id
         object_id = change.changed_object_id
@@ -744,7 +747,6 @@ class Branch(JobsMixin, PrimaryModel):
                 # can do an in-memory check instead of a per-change ChangeDiff.exists() query.
                 # _apply_sync_update never creates a new ChangeDiff (it only updates
                 # existing ones via record_change_diff), so the set is stable for the loop.
-                from .changes import ChangeDiff
                 touched_object_keys = set(
                     ChangeDiff.objects.filter(branch=self).values_list('object_type_id', 'object_id')
                 )

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -551,11 +551,9 @@ class Branch(JobsMixin, PrimaryModel):
 
     def _apply_sync_update(self, change, user, logger, request_id):
         """
-        Apply a non-DELETE change from main to the branch schema. When the branch has
-        also touched the same object (an existing ChangeDiff indicates a branch-side
-        ObjectChange exists), record a sync-originated ObjectChange in the branch
-        schema so the merge replay produces the synced value rather than the branch's
-        stale pre-sync value (issue #28).
+        Apply a non-DELETE change from main and, when the branch has also touched the
+        same object, record a sync-originated ObjectChange so the merge replay does
+        not undo it (#28).
         """
         # Avoid a circular import
         from .changes import ChangeDiff
@@ -564,8 +562,7 @@ class Branch(JobsMixin, PrimaryModel):
         content_type = change.changed_object_type
         object_id = change.changed_object_id
 
-        # If the branch has not touched this object, no merge-time conflict is possible —
-        # apply the change with no further bookkeeping (preserves the historical fast path).
+        # If the branch has not touched this object, no merge-time conflict is possible
         has_branch_change = ChangeDiff.objects.filter(
             branch=self, object_type=content_type, object_id=object_id,
         ).exists()
@@ -581,7 +578,7 @@ class Branch(JobsMixin, PrimaryModel):
             else:
                 prechange_data = serialize_object(before, exclude=['created', 'last_updated'])
         except model_class.DoesNotExist:
-            # Branch already removed the object; let apply() decide what to do (skip_missing).
+            # Branch already removed the object; let apply() handle it via skip_missing
             change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
             return
 
@@ -600,13 +597,8 @@ class Branch(JobsMixin, PrimaryModel):
         if prechange_data == postchange_data:
             return
 
-        # Record the sync as an ObjectChange in the branch schema. The merge replay
-        # of this entry overwrites whatever the branch's earlier change set, restoring
-        # the value that was accepted from main during the sync. Create through the
-        # core (non-proxy) model so the post_save signal reaches receivers registered
-        # against core.models.ObjectChange — Django sends proxy-model signals with the
-        # proxy class as sender, which would otherwise bypass record_change_diff and
-        # leave ChangeDiff.modified (and the conflict marker) stale.
+        # Create via the core model, not the proxy: Django dispatches proxy post_save
+        # with the proxy as sender, which would bypass record_change_diff.
         ObjectChange_.objects.using(self.connection_name).create(
             action=ObjectChangeActionChoices.ACTION_UPDATE,
             changed_object_type=content_type,

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -549,6 +549,80 @@ class Branch(JobsMixin, PrimaryModel):
     # Branch actions
     #
 
+    def _apply_sync_update(self, change, user, logger, request_id):
+        """
+        Apply a non-DELETE change from main to the branch schema. When the branch has
+        also touched the same object (an existing ChangeDiff indicates a branch-side
+        ObjectChange exists), record a sync-originated ObjectChange in the branch
+        schema so the merge replay produces the synced value rather than the branch's
+        stale pre-sync value (issue #28).
+        """
+        # Avoid a circular import
+        from .changes import ChangeDiff
+
+        model_class = change.changed_object_type.model_class()
+        content_type = change.changed_object_type
+        object_id = change.changed_object_id
+
+        # If the branch has not touched this object, no merge-time conflict is possible —
+        # apply the change with no further bookkeeping (preserves the historical fast path).
+        has_branch_change = ChangeDiff.objects.filter(
+            branch=self, object_type=content_type, object_id=object_id,
+        ).exists()
+        if not has_branch_change:
+            change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
+            return
+
+        # Capture the branch's state before applying main's change
+        try:
+            before = model_class.objects.using(self.connection_name).get(pk=object_id)
+            if hasattr(before, 'serialize_object'):
+                prechange_data = before.serialize_object(exclude=['created', 'last_updated'])
+            else:
+                prechange_data = serialize_object(before, exclude=['created', 'last_updated'])
+        except model_class.DoesNotExist:
+            # Branch already removed the object; let apply() decide what to do (skip_missing).
+            change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
+            return
+
+        # Apply the change from main onto the branch
+        change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
+
+        # Capture the branch's state after applying main's change
+        try:
+            after = model_class.objects.using(self.connection_name).get(pk=object_id)
+        except model_class.DoesNotExist:
+            return
+        if hasattr(after, 'serialize_object'):
+            postchange_data = after.serialize_object(exclude=['created', 'last_updated'])
+        else:
+            postchange_data = serialize_object(after, exclude=['created', 'last_updated'])
+        if prechange_data == postchange_data:
+            return
+
+        # Record the sync as an ObjectChange in the branch schema. The merge replay
+        # of this entry overwrites whatever the branch's earlier change set, restoring
+        # the value that was accepted from main during the sync. Create through the
+        # core (non-proxy) model so the post_save signal reaches receivers registered
+        # against core.models.ObjectChange — Django sends proxy-model signals with the
+        # proxy class as sender, which would otherwise bypass record_change_diff and
+        # leave ChangeDiff.modified (and the conflict marker) stale.
+        ObjectChange_.objects.using(self.connection_name).create(
+            action=ObjectChangeActionChoices.ACTION_UPDATE,
+            changed_object_type=content_type,
+            changed_object_id=object_id,
+            object_repr=str(after),
+            prechange_data=prechange_data,
+            postchange_data=postchange_data,
+            user=user,
+            user_name=user.username if user else '',
+            request_id=request_id,
+        )
+        logger.debug(
+            f'Recorded sync-applied change to {model_class._meta.verbose_name} {after} '
+            f'(supersedes prior branch change on conflicting fields)'
+        )
+
     def _handle_sync_delete(self, change, branchable_models, user, logger, request_id=None):
         """
         Apply a DELETE change to the branch schema and record ObjectChange entries for any
@@ -662,7 +736,7 @@ class Branch(JobsMixin, PrimaryModel):
                         )
                         models.update(cascade_models)
                     else:
-                        change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
+                        self._apply_sync_update(change, user, logger, request_id)
 
                 if not commit:
                     raise AbortTransaction()

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -63,11 +63,6 @@ __all__ = (
 # of SET LOCAL — value is passed as a query parameter rather than interpolated.
 _SET_SEARCH_PATH = "SELECT pg_catalog.set_config('search_path', %s, true)"
 
-# Max length of ObjectChange.message, cached at import time to avoid a _meta lookup
-# inside the sync loop.
-_OBJECTCHANGE_MESSAGE_MAX_LENGTH = ObjectChange_._meta.get_field('message').max_length
-
-
 def _serialize_for_sync(obj):
     """
     Serialize an object for sync-time pre/post snapshots, matching the format
@@ -650,6 +645,7 @@ class Branch(JobsMixin, PrimaryModel):
             return
 
         user_name = user.username if user else ''
+        message_max_length = ObjectChange_._meta.get_field('message').max_length
 
         for entry in sync_buffer.values():
             # Drop entries whose consolidated net change is a no-op (e.g. main
@@ -660,7 +656,7 @@ class Branch(JobsMixin, PrimaryModel):
             originals = ', '.join(entry['user_names']) or 'system'
             sync_message = (
                 f'Synced from main (originally by {originals})'
-            )[:_OBJECTCHANGE_MESSAGE_MAX_LENGTH]
+            )[:message_max_length]
 
             ObjectChange_.objects.using(self.connection_name).create(
                 action=ObjectChangeActionChoices.ACTION_UPDATE,

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -599,6 +599,7 @@ class Branch(JobsMixin, PrimaryModel):
 
         # Create via the core model, not the proxy: Django dispatches proxy post_save
         # with the proxy as sender, which would bypass record_change_diff.
+        sync_message = f'Applied from branch sync (main change by {change.user_name or "system"})'[:200]
         ObjectChange_.objects.using(self.connection_name).create(
             action=ObjectChangeActionChoices.ACTION_UPDATE,
             changed_object_type=content_type,
@@ -609,6 +610,7 @@ class Branch(JobsMixin, PrimaryModel):
             user=user,
             user_name=user.username if user else '',
             request_id=request_id,
+            message=sync_message,
         )
         logger.debug(
             f'Recorded sync-applied change to {model_class._meta.verbose_name} {after} '

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -63,6 +63,23 @@ __all__ = (
 # of SET LOCAL — value is passed as a query parameter rather than interpolated.
 _SET_SEARCH_PATH = "SELECT pg_catalog.set_config('search_path', %s, true)"
 
+# Max length of ObjectChange.message, cached at import time to avoid a _meta lookup
+# inside the sync loop.
+_OBJECTCHANGE_MESSAGE_MAX_LENGTH = ObjectChange_._meta.get_field('message').max_length
+
+
+def _serialize_for_sync(obj):
+    """
+    Serialize an object for sync-time pre/post snapshots, matching the format
+    record_change_diff expects on ObjectChange.postchange_data_clean.
+
+    Defensive: every branchable model inherits ChangeLoggingMixin.serialize_object,
+    so the utility-function fallback should not be reached in practice.
+    """
+    if hasattr(obj, 'serialize_object'):
+        return obj.serialize_object(exclude=['created', 'last_updated'])
+    return serialize_object(obj, exclude=['created', 'last_updated'])
+
 
 @contextmanager
 def _branch_isolated_runsql(branch_schema, main_schema):
@@ -549,38 +566,30 @@ class Branch(JobsMixin, PrimaryModel):
     # Branch actions
     #
 
-    def _apply_sync_update(self, change, user, logger, request_id):
+    def _apply_sync_update(self, change, user, logger, request_id, touched_object_keys):
         """
         Apply a non-DELETE change from main and, when the branch has also touched the
         same object, record a sync-originated ObjectChange so the merge replay does
         not undo it (#28).
-        """
-        # Avoid a circular import
-        from .changes import ChangeDiff
 
-        model_class = change.changed_object_type.model_class()
-        content_type = change.changed_object_type
+        ``touched_object_keys`` is a set of ``(content_type_id, object_id)`` tuples
+        for which the branch has at least one ChangeDiff. It is pre-fetched once by
+        the caller to avoid an N+1 query inside the sync loop.
+        """
+        content_type_id = change.changed_object_type_id
         object_id = change.changed_object_id
 
         # If the branch has not touched this object, no merge-time conflict is possible
-        has_branch_change = ChangeDiff.objects.filter(
-            branch=self, object_type=content_type, object_id=object_id,
-        ).exists()
-        if not has_branch_change:
+        if (content_type_id, object_id) not in touched_object_keys:
             change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
             return
 
-        # Defensive: every branchable model inherits ChangeLoggingMixin.serialize_object,
-        # so the utility-function fallback should not be reached in practice.
-        def _serialize(obj):
-            if hasattr(obj, 'serialize_object'):
-                return obj.serialize_object(exclude=['created', 'last_updated'])
-            return serialize_object(obj, exclude=['created', 'last_updated'])
+        model_class = change.changed_object_type.model_class()
 
         # Capture the branch's state before applying main's change
         try:
             before = model_class.objects.using(self.connection_name).get(pk=object_id)
-            prechange_data = _serialize(before)
+            prechange_data = _serialize_for_sync(before)
         except model_class.DoesNotExist:
             # Branch already removed the object; let apply() handle it via skip_missing
             change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
@@ -594,19 +603,18 @@ class Branch(JobsMixin, PrimaryModel):
             after = model_class.objects.using(self.connection_name).get(pk=object_id)
         except model_class.DoesNotExist:
             return
-        postchange_data = _serialize(after)
+        postchange_data = _serialize_for_sync(after)
         if prechange_data == postchange_data:
             return
 
         # Create via the core model, not the proxy: Django dispatches proxy post_save
         # with the proxy as sender, which would bypass record_change_diff.
-        message_max_length = ObjectChange_._meta.get_field('message').max_length
         sync_message = (
             f'Synced from main (originally by {change.user_name or "system"})'
-        )[:message_max_length]
+        )[:_OBJECTCHANGE_MESSAGE_MAX_LENGTH]
         ObjectChange_.objects.using(self.connection_name).create(
             action=ObjectChangeActionChoices.ACTION_UPDATE,
-            changed_object_type=content_type,
+            changed_object_type_id=content_type_id,
             changed_object_id=object_id,
             object_repr=str(after),
             prechange_data=prechange_data,
@@ -732,6 +740,15 @@ class Branch(JobsMixin, PrimaryModel):
                 models = set()
                 branchable_models = {ct.model_class() for ct in get_branchable_object_types()}
 
+                # Pre-fetch the set of objects the branch has touched so _apply_sync_update
+                # can do an in-memory check instead of a per-change ChangeDiff.exists() query.
+                # _apply_sync_update never creates a new ChangeDiff (it only updates
+                # existing ones via record_change_diff), so the set is stable for the loop.
+                from .changes import ChangeDiff
+                touched_object_keys = set(
+                    ChangeDiff.objects.filter(branch=self).values_list('object_type_id', 'object_id')
+                )
+
                 # Apply each change from the main schema
                 for change in changes:
                     model_class = change.changed_object_type.model_class()
@@ -742,7 +759,7 @@ class Branch(JobsMixin, PrimaryModel):
                         )
                         models.update(cascade_models)
                     else:
-                        self._apply_sync_update(change, user, logger, request_id)
+                        self._apply_sync_update(change, user, logger, request_id, touched_object_keys)
 
                 if not commit:
                     raise AbortTransaction()

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -599,7 +599,10 @@ class Branch(JobsMixin, PrimaryModel):
 
         # Create via the core model, not the proxy: Django dispatches proxy post_save
         # with the proxy as sender, which would bypass record_change_diff.
-        sync_message = f'Applied from branch sync (main change by {change.user_name or "system"})'[:200]
+        message_max_length = ObjectChange_._meta.get_field('message').max_length
+        sync_message = (
+            f'Applied from branch sync (main change by {change.user_name or "system"})'
+        )[:message_max_length]
         ObjectChange_.objects.using(self.connection_name).create(
             action=ObjectChangeActionChoices.ACTION_UPDATE,
             changed_object_type=content_type,
@@ -716,7 +719,13 @@ class Branch(JobsMixin, PrimaryModel):
         request_id = uuid.uuid4()
 
         try:
-            with activate_branch(self), transaction.atomic(using=self.connection_name):
+            # Wrap both the default DB and the branch schema in atomic blocks so that
+            # ChangeDiff updates (written to the default DB via record_change_diff
+            # when the synthetic ObjectChange is saved) roll back together with the
+            # branch-schema writes if AbortTransaction is raised (e.g. commit=False).
+            with activate_branch(self), \
+                    transaction.atomic(using=DEFAULT_DB_ALIAS), \
+                    transaction.atomic(using=self.connection_name):
                 models = set()
                 branchable_models = {ct.model_class() for ct in get_branchable_object_types()}
 

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -570,13 +570,17 @@ class Branch(JobsMixin, PrimaryModel):
             change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
             return
 
+        # Defensive: every branchable model inherits ChangeLoggingMixin.serialize_object,
+        # so the utility-function fallback should not be reached in practice.
+        def _serialize(obj):
+            if hasattr(obj, 'serialize_object'):
+                return obj.serialize_object(exclude=['created', 'last_updated'])
+            return serialize_object(obj, exclude=['created', 'last_updated'])
+
         # Capture the branch's state before applying main's change
         try:
             before = model_class.objects.using(self.connection_name).get(pk=object_id)
-            if hasattr(before, 'serialize_object'):
-                prechange_data = before.serialize_object(exclude=['created', 'last_updated'])
-            else:
-                prechange_data = serialize_object(before, exclude=['created', 'last_updated'])
+            prechange_data = _serialize(before)
         except model_class.DoesNotExist:
             # Branch already removed the object; let apply() handle it via skip_missing
             change.apply(self, using=self.connection_name, logger=logger, skip_missing=True)
@@ -590,10 +594,7 @@ class Branch(JobsMixin, PrimaryModel):
             after = model_class.objects.using(self.connection_name).get(pk=object_id)
         except model_class.DoesNotExist:
             return
-        if hasattr(after, 'serialize_object'):
-            postchange_data = after.serialize_object(exclude=['created', 'last_updated'])
-        else:
-            postchange_data = serialize_object(after, exclude=['created', 'last_updated'])
+        postchange_data = _serialize(after)
         if prechange_data == postchange_data:
             return
 
@@ -601,7 +602,7 @@ class Branch(JobsMixin, PrimaryModel):
         # with the proxy as sender, which would bypass record_change_diff.
         message_max_length = ObjectChange_._meta.get_field('message').max_length
         sync_message = (
-            f'Applied from branch sync (main change by {change.user_name or "system"})'
+            f'Synced from main (originally by {change.user_name or "system"})'
         )[:message_max_length]
         ObjectChange_.objects.using(self.connection_name).create(
             action=ObjectChangeActionChoices.ACTION_UPDATE,
@@ -723,9 +724,11 @@ class Branch(JobsMixin, PrimaryModel):
             # ChangeDiff updates (written to the default DB via record_change_diff
             # when the synthetic ObjectChange is saved) roll back together with the
             # branch-schema writes if AbortTransaction is raised (e.g. commit=False).
-            with activate_branch(self), \
-                    transaction.atomic(using=DEFAULT_DB_ALIAS), \
-                    transaction.atomic(using=self.connection_name):
+            with (
+                activate_branch(self),
+                transaction.atomic(using=DEFAULT_DB_ALIAS),
+                transaction.atomic(using=self.connection_name),
+            ):
                 models = set()
                 branchable_models = {ct.model_class() for ct in get_branchable_object_types()}
 

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -63,6 +63,7 @@ __all__ = (
 # of SET LOCAL — value is passed as a query parameter rather than interpolated.
 _SET_SEARCH_PATH = "SELECT pg_catalog.set_config('search_path', %s, true)"
 
+
 def _serialize_for_sync(obj):
     """
     Serialize an object for sync-time pre/post snapshots, matching the format

--- a/netbox_branching/tests/test_sync.py
+++ b/netbox_branching/tests/test_sync.py
@@ -267,8 +267,7 @@ class SyncTestCase(TransactionTestCase):
         # ChangeDiff records a conflict on status
         content_type = ContentType.objects.get_for_model(Site)
         diff = ChangeDiff.objects.get(branch=branch, object_type=content_type, object_id=site_id)
-        self.assertIsNotNone(diff.conflicts)
-        self.assertIn('status', diff.conflicts)
+        self.assertIn('status', diff.conflicts or [])
 
         # Sync: main's value (staging) overwrites the branch's value (planned)
         branch.sync(user=self.user, commit=True)

--- a/netbox_branching/tests/test_sync.py
+++ b/netbox_branching/tests/test_sync.py
@@ -33,7 +33,7 @@ from django.urls import reverse
 from extras.models import Tag
 from netbox.context_managers import event_tracking
 
-from netbox_branching.choices import BranchStatusChoices
+from netbox_branching.choices import BranchMergeStrategyChoices, BranchStatusChoices
 from netbox_branching.models import Branch, ChangeDiff
 from netbox_branching.utilities import activate_branch
 
@@ -77,9 +77,9 @@ class SyncTestCase(TransactionTestCase):
             if hasattr(connections, branch.connection_name):
                 connections[branch.connection_name].close()
 
-    def _create_and_provision_branch(self, name='Test Branch'):
+    def _create_and_provision_branch(self, name='Test Branch', merge_strategy=BranchMergeStrategyChoices.SQUASH):
         """Helper to create and provision a branch, waiting until READY."""
-        branch = Branch(name=name, merge_strategy='squash')
+        branch = Branch(name=name, merge_strategy=merge_strategy)
         branch.save(provision=False)
         branch.provision(user=self.user)
 
@@ -231,6 +231,66 @@ class SyncTestCase(TransactionTestCase):
 
         branch.refresh_from_db()
         self.assertGreater(branch.last_sync, initial_last_sync)
+
+    def _run_sync_conflict_merge_scenario(self, merge_strategy):
+        """
+        Reproduce issue #28 against a specific merge strategy: branch and main both
+        modify site.status, the branch is synced (accepting main's value), and the
+        branch is then merged. Merging must preserve main's synced value.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(
+                name=f'Conflict Site {merge_strategy}',
+                slug=f'conflict-site-{merge_strategy}',
+                status='active',
+            )
+            site_id = site.id
+
+        branch = self._create_and_provision_branch(
+            name=f'Conflict Branch {merge_strategy}', merge_strategy=merge_strategy,
+        )
+
+        # Main: active → staging
+        with event_tracking(self.request):
+            main_site = Site.objects.get(id=site_id)
+            main_site.snapshot()
+            main_site.status = 'staging'
+            main_site.save()
+
+        # Branch: active → planned
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(id=site_id)
+            branch_site.snapshot()
+            branch_site.status = 'planned'
+            branch_site.save()
+
+        # ChangeDiff records a conflict on status
+        content_type = ContentType.objects.get_for_model(Site)
+        diff = ChangeDiff.objects.get(branch=branch, object_type=content_type, object_id=site_id)
+        self.assertIsNotNone(diff.conflicts)
+        self.assertIn('status', diff.conflicts)
+
+        # Sync: main's value (staging) overwrites the branch's value (planned)
+        branch.sync(user=self.user, commit=True)
+
+        with activate_branch(branch):
+            self.assertEqual(Site.objects.get(id=site_id).status, 'staging')
+
+        # The acknowledged conflict should no longer appear on the ChangeDiff
+        diff.refresh_from_db()
+        self.assertIsNone(diff.conflicts)
+
+        # Merge: main must keep the synced value, not revert to the branch's pre-sync value
+        branch.merge(user=self.user, commit=True)
+        self.assertEqual(Site.objects.get(id=site_id).status, 'staging')
+
+    def test_sync_conflict_resolution_preserved_on_merge_squash(self):
+        """Regression test for issue #28 against the squash merge strategy."""
+        self._run_sync_conflict_merge_scenario(BranchMergeStrategyChoices.SQUASH)
+
+    def test_sync_conflict_resolution_preserved_on_merge_iterative(self):
+        """Regression test for issue #28 against the iterative merge strategy."""
+        self._run_sync_conflict_merge_scenario(BranchMergeStrategyChoices.ITERATIVE)
 
     def test_sync_m2m_tags_concurrent_changes(self):
         """

--- a/netbox_branching/tests/test_sync.py
+++ b/netbox_branching/tests/test_sync.py
@@ -382,11 +382,25 @@ class SyncTestCase(TransactionTestCase):
             main_site.status = 'staging'
             main_site.save()
 
+        # Capture the branch's ObjectChange count for this site before sync so we can
+        # assert that the early-return path did not write a synthetic ObjectChange.
+        from core.models import ObjectChange as CoreObjectChange
+        content_type = ContentType.objects.get_for_model(Site)
+        pre_sync_change_count = CoreObjectChange.objects.using(branch.connection_name).filter(
+            changed_object_type=content_type, changed_object_id=site_id,
+        ).count()
+
         # Sync should not raise; main's update lands on a branch row that no longer exists
         branch.sync(user=self.user, commit=True)
 
         with activate_branch(branch):
             self.assertFalse(Site.objects.filter(id=site_id).exists())
+
+        # No synthetic ObjectChange should have been written for this object during sync
+        post_sync_change_count = CoreObjectChange.objects.using(branch.connection_name).filter(
+            changed_object_type=content_type, changed_object_id=site_id,
+        ).count()
+        self.assertEqual(post_sync_change_count, pre_sync_change_count)
 
         # Merge: branch's DELETE wins on main
         branch.merge(user=self.user, commit=True)

--- a/netbox_branching/tests/test_sync.py
+++ b/netbox_branching/tests/test_sync.py
@@ -12,6 +12,7 @@ applied iteratively in chronological order.
 import time
 import uuid
 
+from core.models import ObjectChange as CoreObjectChange
 from dcim.models import (
     Cable,
     CablePath,
@@ -384,7 +385,6 @@ class SyncTestCase(TransactionTestCase):
 
         # Capture the branch's ObjectChange count for this site before sync so we can
         # assert that the early-return path did not write a synthetic ObjectChange.
-        from core.models import ObjectChange as CoreObjectChange
         content_type = ContentType.objects.get_for_model(Site)
         pre_sync_change_count = CoreObjectChange.objects.using(branch.connection_name).filter(
             changed_object_type=content_type, changed_object_id=site_id,

--- a/netbox_branching/tests/test_sync.py
+++ b/netbox_branching/tests/test_sync.py
@@ -291,6 +291,182 @@ class SyncTestCase(TransactionTestCase):
         """Regression test for issue #28 against the iterative merge strategy."""
         self._run_sync_conflict_merge_scenario(BranchMergeStrategyChoices.ITERATIVE)
 
+    def _run_sync_partial_field_overlap_scenario(self, merge_strategy):
+        """
+        Branch and main edit the same object but different fields (no field-level conflict).
+        Sync must not let main's edit silently overwrite the branch's unrelated edit, and
+        merge must carry both changes through to main.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(
+                name=f'Partial Site {merge_strategy}',
+                slug=f'partial-site-{merge_strategy}',
+                status='active',
+                description='original',
+            )
+            site_id = site.id
+
+        branch = self._create_and_provision_branch(
+            name=f'Partial Branch {merge_strategy}', merge_strategy=merge_strategy,
+        )
+
+        # Main: status active → staging (description unchanged)
+        with event_tracking(self.request):
+            main_site = Site.objects.get(id=site_id)
+            main_site.snapshot()
+            main_site.status = 'staging'
+            main_site.save()
+
+        # Branch: description original → branch-desc (status unchanged)
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(id=site_id)
+            branch_site.snapshot()
+            branch_site.description = 'branch-desc'
+            branch_site.save()
+
+        # No field-level conflict: branch and main touched different fields
+        content_type = ContentType.objects.get_for_model(Site)
+        diff = ChangeDiff.objects.get(branch=branch, object_type=content_type, object_id=site_id)
+        self.assertIsNone(diff.conflicts)
+
+        branch.sync(user=self.user, commit=True)
+
+        # After sync, branch carries main's status and its own description
+        with activate_branch(branch):
+            synced = Site.objects.get(id=site_id)
+            self.assertEqual(synced.status, 'staging')
+            self.assertEqual(synced.description, 'branch-desc')
+
+        branch.merge(user=self.user, commit=True)
+
+        # After merge, main keeps its synced status and gains the branch's description
+        merged = Site.objects.get(id=site_id)
+        self.assertEqual(merged.status, 'staging')
+        self.assertEqual(merged.description, 'branch-desc')
+
+    def test_sync_partial_field_overlap_squash(self):
+        """Branch and main edit different fields on the same object (squash)."""
+        self._run_sync_partial_field_overlap_scenario(BranchMergeStrategyChoices.SQUASH)
+
+    def test_sync_partial_field_overlap_iterative(self):
+        """Branch and main edit different fields on the same object (iterative)."""
+        self._run_sync_partial_field_overlap_scenario(BranchMergeStrategyChoices.ITERATIVE)
+
+    def _run_sync_branch_deleted_main_updated_scenario(self, merge_strategy):
+        """
+        Branch deletes an object that main subsequently updates. Sync must apply main's
+        update against a branch that no longer has the row (exercising the DoesNotExist
+        path in _apply_sync_update) without raising or writing a synthetic ObjectChange.
+        Merge must carry the branch's DELETE through to main.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(
+                name=f'Deleted Site {merge_strategy}',
+                slug=f'deleted-site-{merge_strategy}',
+                status='active',
+            )
+            site_id = site.id
+
+        branch = self._create_and_provision_branch(
+            name=f'Deleted Branch {merge_strategy}', merge_strategy=merge_strategy,
+        )
+
+        # Branch: delete the site
+        with activate_branch(branch), event_tracking(self.request):
+            Site.objects.get(id=site_id).delete()
+
+        # Main: update the site (after the branch's delete)
+        with event_tracking(self.request):
+            main_site = Site.objects.get(id=site_id)
+            main_site.snapshot()
+            main_site.status = 'staging'
+            main_site.save()
+
+        # Sync should not raise; main's update lands on a branch row that no longer exists
+        branch.sync(user=self.user, commit=True)
+
+        with activate_branch(branch):
+            self.assertFalse(Site.objects.filter(id=site_id).exists())
+
+        # Merge: branch's DELETE wins on main
+        branch.merge(user=self.user, commit=True)
+        self.assertFalse(Site.objects.filter(id=site_id).exists())
+
+    def test_sync_branch_deleted_main_updated_squash(self):
+        """Branch deletes an object that main later updates (squash)."""
+        self._run_sync_branch_deleted_main_updated_scenario(BranchMergeStrategyChoices.SQUASH)
+
+    def test_sync_branch_deleted_main_updated_iterative(self):
+        """Branch deletes an object that main later updates (iterative)."""
+        self._run_sync_branch_deleted_main_updated_scenario(BranchMergeStrategyChoices.ITERATIVE)
+
+    def _run_sync_multi_field_conflict_scenario(self, merge_strategy):
+        """
+        Branch and main both edit the conflicting field (status), and the branch
+        additionally edits a non-conflicting field (description). Sync accepts main's
+        status; merge must preserve both main's synced status and the branch's
+        description change.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(
+                name=f'MultiField Site {merge_strategy}',
+                slug=f'multifield-site-{merge_strategy}',
+                status='active',
+                description='original',
+            )
+            site_id = site.id
+
+        branch = self._create_and_provision_branch(
+            name=f'MultiField Branch {merge_strategy}', merge_strategy=merge_strategy,
+        )
+
+        # Main: status active → staging
+        with event_tracking(self.request):
+            main_site = Site.objects.get(id=site_id)
+            main_site.snapshot()
+            main_site.status = 'staging'
+            main_site.save()
+
+        # Branch: status active → planned AND description original → branch-desc
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(id=site_id)
+            branch_site.snapshot()
+            branch_site.status = 'planned'
+            branch_site.description = 'branch-desc'
+            branch_site.save()
+
+        # Conflict is limited to status; description is only changed in the branch
+        content_type = ContentType.objects.get_for_model(Site)
+        diff = ChangeDiff.objects.get(branch=branch, object_type=content_type, object_id=site_id)
+        self.assertIn('status', diff.conflicts or [])
+        self.assertNotIn('description', diff.conflicts or [])
+
+        branch.sync(user=self.user, commit=True)
+
+        with activate_branch(branch):
+            synced = Site.objects.get(id=site_id)
+            self.assertEqual(synced.status, 'staging')
+            self.assertEqual(synced.description, 'branch-desc')
+
+        # The acknowledged conflict on status should be cleared
+        diff.refresh_from_db()
+        self.assertIsNone(diff.conflicts)
+
+        branch.merge(user=self.user, commit=True)
+
+        # Main retains its synced status (not 'planned') and gains the branch's description
+        merged = Site.objects.get(id=site_id)
+        self.assertEqual(merged.status, 'staging')
+        self.assertEqual(merged.description, 'branch-desc')
+
+    def test_sync_multi_field_conflict_squash(self):
+        """End-to-end multi-field sync + merge (squash)."""
+        self._run_sync_multi_field_conflict_scenario(BranchMergeStrategyChoices.SQUASH)
+
+    def test_sync_multi_field_conflict_iterative(self):
+        """End-to-end multi-field sync + merge (iterative)."""
+        self._run_sync_multi_field_conflict_scenario(BranchMergeStrategyChoices.ITERATIVE)
+
     def test_sync_m2m_tags_concurrent_changes(self):
         """
         Test sync with concurrent many-to-many (tag) changes in both main and branch.


### PR DESCRIPTION
### Fixes: #28 

For a conflict, instead of changing the existing ObjectChange as suggested in the issue, this creates a new ObjectChange with the updated change. This keeps the ObjectChange immutable and matches what we do elsewhere.  It makes it so there is no conflict shown anymore and has a changelog message that it comes from the sync.

During sync, for each non-DELETE change from main against an object the branch has also touched:

- Capture the branch's pre-sync state of the object
- Apply main's change to the branch schema
- Capture the branch's post-sync state
- If the state changed, write a synthetic ObjectChange (prechange = pre-sync, postchange = post-sync) into the branch schema
- Create it via the core ObjectChange model (not the proxy) so record_change_diff fires and clears the acknowledged conflict on the existing ChangeDiff

Merge replay (iterative and squash) then sees the synthetic update last and lands on main's synced value.