### PR TITLE
Fix test_filtersets.py test due to recent NetBox change

### DIFF
--- a/netbox_branching/tests/test_filtersets.py
+++ b/netbox_branching/tests/test_filtersets.py
@@ -60,7 +60,7 @@ class BaseFilterSetTests:
             return [(f'{related_name}_id', django_filters.ModelMultipleChoiceFilter)]
 
         # Tags
-        if TaggableManager is not None and type(field) is TaggableManager:
+        if TaggableManager is not None and isinstance(field, TaggableManager):
             return [('tag', None)]
 
         # All other fields – just check presence, not class


### PR DESCRIPTION
### Fixes: #578 

NetBox upstream commit 4eb0e727b (PR #22323) replaced tags = TaggableManager(...) on TagsMixin with a subclass, tags = NetBoxTaggableManagerField(...).

changed type(field) is TaggableManager → isinstance(field, TaggableManager) in netbox_branching/tests/test_filtersets.py