### PR TITLE
#6 - Under branch view group change records by request

### DIFF
--- a/netbox_branching/tables/tables.py
+++ b/netbox_branching/tables/tables.py
@@ -62,10 +62,14 @@ OBJECTCHANGE_REQUEST_ID = """
 
 GROUPED_TYPE = (
     '{% if record.changed_object_type %}'
+    '{{ record.changed_object_type.name|capfirst }}'
+    '{% endif %}'
+)
+
+GROUPED_REQUEST_ID = (
     '<a href="?request_id={{ record.request_id }}'
     '&changed_object_type_id={{ record.changed_object_type_id }}">'
-    "{{ record.changed_object_type|stringformat:'s'|capfirst }}</a>"
-    '{% endif %}'
+    '{{ record.request_id }}</a>'
 )
 
 GROUPED_COUNT = (
@@ -253,14 +257,15 @@ class ChangesGroupedTable(BaseTable):
         verbose_name=_('Deleted'),
         attrs={'td': {'class': 'text-end'}, 'th': {'class': 'text-end'}},
     )
-    request_id = tables.Column(
+    request_id = tables.TemplateColumn(
+        template_code=GROUPED_REQUEST_ID,
         verbose_name=_('Request ID'),
-        accessor='request_id',
+        order_by='request_id',
     )
 
     class Meta(BaseTable.Meta):
         model = ObjectChange
         fields = (
-            'time', 'user_name', 'changed_object_type', 'creates', 'updates', 'deletes', 'request_id',
+            'time', 'user_name', 'changed_object_type', 'request_id', 'creates', 'updates', 'deletes',
         )
         default_columns = fields

--- a/netbox_branching/tables/tables.py
+++ b/netbox_branching/tables/tables.py
@@ -67,9 +67,7 @@ GROUPED_TYPE = (
 )
 
 GROUPED_REQUEST_ID = (
-    '<a href="?request_id={{ record.request_id }}'
-    '&changed_object_type_id={{ record.changed_object_type_id }}">'
-    '{{ record.request_id }}</a>'
+    '<a href="?request_id={{ record.request_id }}">{{ record.request_id }}</a>'
 )
 
 GROUPED_COUNT = (

--- a/netbox_branching/tables/tables.py
+++ b/netbox_branching/tables/tables.py
@@ -2,7 +2,7 @@ import django_tables2 as tables
 from core.models import ObjectChange
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from netbox.tables import NetBoxTable, columns
+from netbox.tables import BaseTable, NetBoxTable, columns
 from utilities.templatetags.builtins.filters import placeholder
 
 from netbox_branching.models import Branch, ChangeDiff
@@ -12,6 +12,7 @@ from .columns import ConflictsColumn, DiffColumn
 __all__ = (
     'BranchTable',
     'ChangeDiffTable',
+    'ChangesGroupedTable',
     'ChangesTable',
 )
 
@@ -58,6 +59,25 @@ AFTER_DIFF = """
 OBJECTCHANGE_REQUEST_ID = """
 <a href="?request_id={{ value }}">{{ value }}</a>
 """
+
+GROUPED_TYPE = (
+    '{% if record.changed_object_type %}'
+    '<a href="?request_id={{ record.request_id }}'
+    '&changed_object_type_id={{ record.changed_object_type_id }}">'
+    "{{ record.changed_object_type|stringformat:'s'|capfirst }}</a>"
+    '{% endif %}'
+)
+
+GROUPED_COUNT = (
+    '{% load helpers %}'
+    '{% if value %}'
+    '<a href="?request_id={{ record.request_id }}'
+    '&changed_object_type_id={{ record.changed_object_type_id }}'
+    '&action={{ action }}">{{ value }}</a>'
+    '{% else %}'
+    "{{ ''|placeholder }}"
+    '{% endif %}'
+)
 
 
 class BranchTable(NetBoxTable):
@@ -194,3 +214,53 @@ class ChangesTable(NetBoxTable):
         fields = (
             'pk', 'time', 'action', 'model', 'changed_object_type', 'object_repr', 'request_id', 'before', 'after',
         )
+
+
+class ChangesGroupedTable(BaseTable):
+    """
+    Aggregated view of ObjectChange records: one row per (request_id, changed_object_type).
+    Rows are dicts produced by `.values().annotate(...)` in the view.
+    """
+    time = columns.DateTimeColumn(
+        verbose_name=_('Time'),
+        timespec='minutes',
+        accessor='time',
+    )
+    user_name = tables.Column(
+        verbose_name=_('User'),
+        accessor='user_name',
+    )
+    changed_object_type = tables.TemplateColumn(
+        template_code=GROUPED_TYPE,
+        verbose_name=_('Type'),
+        order_by='changed_object_type_id',
+    )
+    creates = tables.TemplateColumn(
+        template_code=GROUPED_COUNT,
+        extra_context={'action': 'create'},
+        verbose_name=_('Created'),
+        attrs={'td': {'class': 'text-end'}, 'th': {'class': 'text-end'}},
+    )
+    updates = tables.TemplateColumn(
+        template_code=GROUPED_COUNT,
+        extra_context={'action': 'update'},
+        verbose_name=_('Updated'),
+        attrs={'td': {'class': 'text-end'}, 'th': {'class': 'text-end'}},
+    )
+    deletes = tables.TemplateColumn(
+        template_code=GROUPED_COUNT,
+        extra_context={'action': 'delete'},
+        verbose_name=_('Deleted'),
+        attrs={'td': {'class': 'text-end'}, 'th': {'class': 'text-end'}},
+    )
+    request_id = tables.Column(
+        verbose_name=_('Request ID'),
+        accessor='request_id',
+    )
+
+    class Meta(BaseTable.Meta):
+        model = ObjectChange
+        fields = (
+            'time', 'user_name', 'changed_object_type', 'creates', 'updates', 'deletes', 'request_id',
+        )
+        default_columns = fields

--- a/netbox_branching/tests/test_views.py
+++ b/netbox_branching/tests/test_views.py
@@ -19,7 +19,8 @@ from netbox_branching.constants import QUERY_PARAM
 from netbox_branching.models import Branch, ChangeDiff
 from netbox_branching.tests.utils import provision_branch
 from netbox_branching.utilities import activate_branch
-from netbox_branching.views import BaseBranchActionView
+from netbox_branching.tables import ChangesGroupedTable, ChangesTable
+from netbox_branching.views import BaseBranchActionView, GroupedChangesViewMixin
 
 User = get_user_model()
 
@@ -692,3 +693,140 @@ class ChangeDiffViewTestCase(TestCase):
         )
         response = self.client.get(self._url(diff))
         self.assertEqual(response.status_code, 200)
+
+
+class GroupedChangesViewMixinTestCase(TestCase):
+    """
+    Unit tests for GroupedChangesViewMixin: aggregation logic and table selection.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.site_ct = ContentType.objects.get(app_label='dcim', model='site')
+        cls.device_ct = ContentType.objects.get(app_label='dcim', model='device')
+
+    @staticmethod
+    def _make_change(request_id, ct, obj_id, action, user_name='alice'):
+        return ObjectChange.objects.create(
+            request_id=request_id,
+            action=action,
+            changed_object_type=ct,
+            changed_object_id=obj_id,
+            user_name=user_name,
+        )
+
+    def test_aggregate_empty_queryset(self):
+        self.assertEqual(GroupedChangesViewMixin._aggregate(ObjectChange.objects.none()), [])
+
+    def test_aggregate_counts_actions_per_group(self):
+        # Single request touching one type with all three actions on different objects
+        req = uuid.uuid4()
+        self._make_change(req, self.site_ct, 1, ObjectChangeActionChoices.ACTION_CREATE)
+        self._make_change(req, self.site_ct, 2, ObjectChangeActionChoices.ACTION_CREATE)
+        self._make_change(req, self.site_ct, 3, ObjectChangeActionChoices.ACTION_UPDATE)
+        self._make_change(req, self.site_ct, 4, ObjectChangeActionChoices.ACTION_DELETE)
+
+        groups = GroupedChangesViewMixin._aggregate(ObjectChange.objects.all())
+
+        self.assertEqual(len(groups), 1)
+        group = groups[0]
+        self.assertEqual(group['request_id'], req)
+        self.assertEqual(group['changed_object_type_id'], self.site_ct.id)
+        self.assertEqual(group['changed_object_type'], self.site_ct)
+        self.assertEqual(group['user_name'], 'alice')
+        self.assertEqual(group['creates'], 2)
+        self.assertEqual(group['updates'], 1)
+        self.assertEqual(group['deletes'], 1)
+
+    def test_aggregate_separates_requests_and_types(self):
+        # Two requests, second one touches two types → three groups total
+        req_a = uuid.uuid4()
+        req_b = uuid.uuid4()
+        self._make_change(req_a, self.site_ct, 1, ObjectChangeActionChoices.ACTION_CREATE)
+        self._make_change(req_b, self.site_ct, 2, ObjectChangeActionChoices.ACTION_UPDATE)
+        self._make_change(req_b, self.device_ct, 1, ObjectChangeActionChoices.ACTION_DELETE)
+
+        groups = GroupedChangesViewMixin._aggregate(ObjectChange.objects.all())
+
+        self.assertEqual(len(groups), 3)
+        keys = {(g['request_id'], g['changed_object_type_id']) for g in groups}
+        self.assertEqual(keys, {
+            (req_a, self.site_ct.id),
+            (req_b, self.site_ct.id),
+            (req_b, self.device_ct.id),
+        })
+
+    def test_aggregate_resolves_content_types(self):
+        # Verify ContentType lookup happens in a single batched query and attaches the object.
+        req = uuid.uuid4()
+        self._make_change(req, self.site_ct, 1, ObjectChangeActionChoices.ACTION_CREATE)
+        self._make_change(req, self.device_ct, 1, ObjectChangeActionChoices.ACTION_CREATE)
+
+        groups = GroupedChangesViewMixin._aggregate(ObjectChange.objects.all())
+
+        resolved = {g['changed_object_type_id']: g['changed_object_type'] for g in groups}
+        self.assertEqual(resolved[self.site_ct.id], self.site_ct)
+        self.assertEqual(resolved[self.device_ct.id], self.device_ct)
+
+    def test_is_drilldown_detects_request_id_param(self):
+        from django.test import RequestFactory
+        factory = RequestFactory()
+        self.assertTrue(GroupedChangesViewMixin._is_drilldown(factory.get('/?request_id=abc')))
+        self.assertFalse(GroupedChangesViewMixin._is_drilldown(factory.get('/')))
+        # Other filter params alone do not trigger drill-down
+        self.assertFalse(GroupedChangesViewMixin._is_drilldown(factory.get('/?action=create')))
+
+
+class BranchChangesViewTableSelectionTestCase(TestCase):
+    """
+    Integration tests for the branch "Changes Behind" view: confirms the grouped
+    table is used by default and the flat ChangesTable is used when drilling down.
+    Uses the "behind" view because its underlying queryset lives in the main DB,
+    so no branch schema needs to be provisioned.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_user(username='grouped_super', is_superuser=True)
+        cls.site_ct = ContentType.objects.get(app_label='dcim', model='site')
+
+        cls.branch = Branch(name='Grouped Test Branch', status=BranchStatusChoices.READY)
+        cls.branch.save(provision=False)
+
+        # Two changes in the same request → one grouped row, two flat rows
+        request_id = uuid.uuid4()
+        cls.request_id = request_id
+        ObjectChange.objects.create(
+            request_id=request_id,
+            action=ObjectChangeActionChoices.ACTION_CREATE,
+            changed_object_type=cls.site_ct,
+            changed_object_id=1,
+            object_repr='Site 1',
+            user_name='alice',
+        )
+        ObjectChange.objects.create(
+            request_id=request_id,
+            action=ObjectChangeActionChoices.ACTION_CREATE,
+            changed_object_type=cls.site_ct,
+            changed_object_id=2,
+            object_repr='Site 2',
+            user_name='alice',
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+        self.url = reverse('plugins:netbox_branching:branch_changes-behind', args=[self.branch.pk])
+
+    def test_default_view_uses_grouped_table(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.context['table'], ChangesGroupedTable)
+        # One grouped row covers both changes
+        self.assertEqual(len(response.context['table'].rows), 1)
+
+    def test_drilldown_uses_flat_table(self):
+        response = self.client.get(f'{self.url}?request_id={self.request_id}')
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.context['table'], ChangesTable)
+        # Flat table shows both raw rows
+        self.assertEqual(len(response.context['table'].rows), 2)

--- a/netbox_branching/tests/test_views.py
+++ b/netbox_branching/tests/test_views.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db import connections
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import RequestFactory, TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django_rq import get_queue
 from utilities.testing import ViewTestCases, create_tags
@@ -17,9 +17,9 @@ from utilities.testing import ViewTestCases, create_tags
 from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.constants import QUERY_PARAM
 from netbox_branching.models import Branch, ChangeDiff
+from netbox_branching.tables import ChangesGroupedTable, ChangesTable
 from netbox_branching.tests.utils import provision_branch
 from netbox_branching.utilities import activate_branch
-from netbox_branching.tables import ChangesGroupedTable, ChangesTable
 from netbox_branching.views import BaseBranchActionView, GroupedChangesViewMixin
 
 User = get_user_model()
@@ -769,7 +769,6 @@ class GroupedChangesViewMixinTestCase(TestCase):
         self.assertEqual(resolved[self.device_ct.id], self.device_ct)
 
     def test_is_drilldown_detects_request_id_param(self):
-        from django.test import RequestFactory
         factory = RequestFactory()
         self.assertTrue(GroupedChangesViewMixin._is_drilldown(factory.get('/?request_id=abc')))
         self.assertFalse(GroupedChangesViewMixin._is_drilldown(factory.get('/')))

--- a/netbox_branching/views.py
+++ b/netbox_branching/views.py
@@ -134,7 +134,7 @@ class GroupedChangesViewMixin:
 
     @staticmethod
     def _is_drilldown(request):
-        return 'request_id' in request.GET and 'changed_object_type_id' in request.GET
+        return 'request_id' in request.GET
 
     @staticmethod
     def _aggregate(qs):

--- a/netbox_branching/views.py
+++ b/netbox_branching/views.py
@@ -126,8 +126,8 @@ class GroupedChangesViewMixin:
     """
     Mixin for branch "Changes" views (Behind / Ahead / Merged). Groups ObjectChange rows
     by (request_id, changed_object_type) for the default listing; falls back to the flat
-    ChangesTable when the drill-down query params (`request_id` and `changed_object_type_id`)
-    are both present.
+    ChangesTable when `request_id` is present in the query string (drill-down from either
+    the Request ID link or a Created/Updated/Deleted count link).
     """
     grouped_table = tables.ChangesGroupedTable
     flat_table = tables.ChangesTable
@@ -139,9 +139,8 @@ class GroupedChangesViewMixin:
     @staticmethod
     def _aggregate(qs):
         groups = list(
-            qs.values('request_id', 'changed_object_type_id').annotate(
+            qs.values('request_id', 'changed_object_type_id', 'user_name').annotate(
                 time=Min('time'),
-                user_name=Min('user_name'),
                 creates=Count('pk', filter=Q(action='create')),
                 updates=Count('pk', filter=Q(action='update')),
                 deletes=Count('pk', filter=Q(action='delete')),
@@ -168,7 +167,6 @@ class BranchChangesBehindView(GroupedChangesViewMixin, generic.ObjectChildrenVie
     queryset = Branch.objects.all()
     child_model = ObjectChange
     filterset = ObjectChangeFilterSet
-    table = tables.ChangesGroupedTable
     actions = {}  # noqa: RUF012
     tab = ViewTab(
         label=_('Changes Behind'),
@@ -185,7 +183,6 @@ class BranchChangesAheadView(GroupedChangesViewMixin, generic.ObjectChildrenView
     queryset = Branch.objects.all()
     child_model = ObjectChange
     filterset = ObjectChangeFilterSet
-    table = tables.ChangesGroupedTable
     actions = {}  # noqa: RUF012
     tab = ViewTab(
         label=_('Changes Ahead'),
@@ -266,7 +263,6 @@ class BranchChangesMergedView(GroupedChangesViewMixin, generic.ObjectChildrenVie
     queryset = Branch.objects.all()
     child_model = ObjectChange
     filterset = ObjectChangeFilterSet
-    table = tables.ChangesGroupedTable
     actions = {}  # noqa: RUF012
     tab = ViewTab(
         label=_('Changes Merged'),

--- a/netbox_branching/views.py
+++ b/netbox_branching/views.py
@@ -6,7 +6,7 @@ from core.models import ObjectChange
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Count, Q
+from django.db.models import Count, Min, Q
 from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
 from netbox.plugins import get_plugin_config
@@ -122,12 +122,53 @@ class BranchDiffView(generic.ObjectChildrenView):
         return ChangeDiff.objects.filter(branch=parent)
 
 
+class GroupedChangesViewMixin:
+    """
+    Mixin for branch "Changes" views (Behind / Ahead / Merged). Groups ObjectChange rows
+    by (request_id, changed_object_type) for the default listing; falls back to the flat
+    ChangesTable when the drill-down query params (`request_id` and `changed_object_type_id`)
+    are both present.
+    """
+    grouped_table = tables.ChangesGroupedTable
+    flat_table = tables.ChangesTable
+
+    @staticmethod
+    def _is_drilldown(request):
+        return 'request_id' in request.GET and 'changed_object_type_id' in request.GET
+
+    @staticmethod
+    def _aggregate(qs):
+        groups = list(
+            qs.values('request_id', 'changed_object_type_id').annotate(
+                time=Min('time'),
+                user_name=Min('user_name'),
+                creates=Count('pk', filter=Q(action='create')),
+                updates=Count('pk', filter=Q(action='update')),
+                deletes=Count('pk', filter=Q(action='delete')),
+            ).order_by('time')
+        )
+        ct_ids = {g['changed_object_type_id'] for g in groups if g['changed_object_type_id']}
+        cts = {ct.id: ct for ct in ContentType.objects.filter(id__in=ct_ids)}
+        for g in groups:
+            g['changed_object_type'] = cts.get(g['changed_object_type_id'])
+        return groups
+
+    def prep_table_data(self, request, queryset, parent):
+        if self._is_drilldown(request):
+            return queryset
+        return self._aggregate(queryset)
+
+    def get_table(self, data, request, bulk_actions=True):
+        self.table = self.flat_table if self._is_drilldown(request) else self.grouped_table
+        return super().get_table(data, request, bulk_actions)
+
+
 @register_model_view(Branch, 'changes-behind')
-class BranchChangesBehindView(generic.ObjectChildrenView):
+class BranchChangesBehindView(GroupedChangesViewMixin, generic.ObjectChildrenView):
     queryset = Branch.objects.all()
     child_model = ObjectChange
     filterset = ObjectChangeFilterSet
-    table = tables.ChangesTable
+    table = tables.ChangesGroupedTable
     actions = {}  # noqa: RUF012
     tab = ViewTab(
         label=_('Changes Behind'),
@@ -140,11 +181,11 @@ class BranchChangesBehindView(generic.ObjectChildrenView):
 
 
 @register_model_view(Branch, 'changes-ahead')
-class BranchChangesAheadView(generic.ObjectChildrenView):
+class BranchChangesAheadView(GroupedChangesViewMixin, generic.ObjectChildrenView):
     queryset = Branch.objects.all()
     child_model = ObjectChange
     filterset = ObjectChangeFilterSet
-    table = tables.ChangesTable
+    table = tables.ChangesGroupedTable
     actions = {}  # noqa: RUF012
     tab = ViewTab(
         label=_('Changes Ahead'),
@@ -221,11 +262,11 @@ def _get_change_count(obj):
 
 
 @register_model_view(Branch, 'changes-merged')
-class BranchChangesMergedView(generic.ObjectChildrenView):
+class BranchChangesMergedView(GroupedChangesViewMixin, generic.ObjectChildrenView):
     queryset = Branch.objects.all()
     child_model = ObjectChange
     filterset = ObjectChangeFilterSet
-    table = tables.ChangesTable
+    table = tables.ChangesGroupedTable
     actions = {}  # noqa: RUF012
     tab = ViewTab(
         label=_('Changes Merged'),

--- a/netbox_branching/views.py
+++ b/netbox_branching/views.py
@@ -129,7 +129,7 @@ class GroupedChangesViewMixin:
     ChangesTable when `request_id` is present in the query string (drill-down from either
     the Request ID link or a Created/Updated/Deleted count link).
     """
-    grouped_table = tables.ChangesGroupedTable
+    table = tables.ChangesGroupedTable
     flat_table = tables.ChangesTable
 
     @staticmethod
@@ -141,9 +141,9 @@ class GroupedChangesViewMixin:
         groups = list(
             qs.values('request_id', 'changed_object_type_id', 'user_name').annotate(
                 time=Min('time'),
-                creates=Count('pk', filter=Q(action='create')),
-                updates=Count('pk', filter=Q(action='update')),
-                deletes=Count('pk', filter=Q(action='delete')),
+                creates=Count('pk', filter=Q(action=ObjectChangeActionChoices.ACTION_CREATE)),
+                updates=Count('pk', filter=Q(action=ObjectChangeActionChoices.ACTION_UPDATE)),
+                deletes=Count('pk', filter=Q(action=ObjectChangeActionChoices.ACTION_DELETE)),
             ).order_by('time')
         )
         ct_ids = {g['changed_object_type_id'] for g in groups if g['changed_object_type_id']}
@@ -158,7 +158,8 @@ class GroupedChangesViewMixin:
         return self._aggregate(queryset)
 
     def get_table(self, data, request, bulk_actions=True):
-        self.table = self.flat_table if self._is_drilldown(request) else self.grouped_table
+        if self._is_drilldown(request):
+            self.table = self.flat_table
         return super().get_table(data, request, bulk_actions)
 
 


### PR DESCRIPTION
### Fixes: #6 

 Groups change records under each branch's Changes Behind / Ahead / Merged tabs by `(request_id, changed_object_type)`, showing one row per type touched in each request with create / update / delete counts. This makes bulk operations (e.g. "created 48 interfaces") readable at a glance.

Before:
<img width="1282" height="1370" alt="Monosnap b1 | NetBox 2026-06-01 14-16-41" src="https://github.com/user-attachments/assets/287c07aa-d3ab-4f30-9a06-4c6a0e7c7807" />

After:
<img width="1276" height="658" alt="Monosnap b1 | NetBox 2026-06-01 14-48-45" src="https://github.com/user-attachments/assets/d9283733-1fe3-4d94-85df-ab20101ea4b9" />

 ## Changes

- New `ChangesGroupedTable` in `tables/tables.py` — columns: Time, User, Type, Request ID, Created, Updated, Deleted.
- New `GroupedChangesViewMixin` in `views.py` that aggregates the `ObjectChange` queryset via `values().annotate()` and renders the grouped table.
- Mixin applied to `BranchChangesBehindView`, `BranchChangesAheadView`, and `BranchChangesMergedView`.