### PR TITLE
Closes #585: Add help text descriptions to BranchStatusChoices

### DIFF
--- a/netbox_branching/choices.py
+++ b/netbox_branching/choices.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from utilities.choices import ChoiceSet
@@ -29,6 +31,20 @@ class BranchStatusChoices(ChoiceSet):
         (PENDING_MIGRATIONS, _('Pending Migrations'), 'red'),
         (FAILED, _('Failed'), 'red'),
     )
+
+    DESCRIPTIONS: ClassVar = {
+        NEW: _('Branch has been created but not yet provisioned.'),
+        PROVISIONING: _('Branch database schema is being set up.'),
+        READY: _('Branch is provisioned and ready for use.'),
+        SYNCING: _('Branch is syncing changes from the main database.'),
+        MIGRATING: _('Database migrations are being applied to the branch.'),
+        MERGING: _('Branch changes are being merged into the main database.'),
+        REVERTING: _('Branch merge is being reverted.'),
+        MERGED: _('Branch has been successfully merged.'),
+        ARCHIVED: _('Branch has been archived and is no longer active.'),
+        PENDING_MIGRATIONS: _('Branch requires database migrations before it can be used.'),
+        FAILED: _('A branch operation has failed.'),
+    }
 
     TRANSITIONAL = (
         PROVISIONING,

--- a/netbox_branching/models/branches.py
+++ b/netbox_branching/models/branches.py
@@ -255,6 +255,9 @@ class Branch(JobsMixin, PrimaryModel):
     def get_status_color(self):
         return BranchStatusChoices.colors.get(self.status)
 
+    def get_status_description(self):
+        return BranchStatusChoices.DESCRIPTIONS.get(self.status, '')
+
     @cached_property
     def is_active(self):
         return self == active_branch.get()

--- a/netbox_branching/tests/test_branches.py
+++ b/netbox_branching/tests/test_branches.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from django.core.exceptions import ValidationError
 from django.db import connection
-from django.test import TransactionTestCase, override_settings
+from django.test import SimpleTestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 from extras.validators import CustomValidator
 from netbox.plugins import get_plugin_config
@@ -449,3 +449,23 @@ class BranchTestCase(TransactionTestCase):
 
         with self.assertRaisesRegex(ValueError, 'Invalid branch action'):
             Branch.register_preaction_check(noop, 'not_a_real_action')
+
+
+class BranchStatusDescriptionTestCase(SimpleTestCase):
+
+    def test_descriptions_cover_all_statuses(self):
+        # Every status choice must have a description, and vice versa.
+        choice_values = {value for value, _ in BranchStatusChoices()}
+        description_keys = set(BranchStatusChoices.DESCRIPTIONS)
+        self.assertEqual(choice_values, description_keys)
+
+    def test_get_status_description(self):
+        branch = Branch(name='Branch 1', status=BranchStatusChoices.READY)
+        self.assertEqual(
+            branch.get_status_description(),
+            BranchStatusChoices.DESCRIPTIONS[BranchStatusChoices.READY]
+        )
+
+    def test_get_status_description_unknown_status(self):
+        branch = Branch(name='Branch 1', status='not-a-real-status')
+        self.assertEqual(branch.get_status_description(), '')


### PR DESCRIPTION
### Closes: #585

Add a `DESCRIPTIONS` dict to `BranchStatusChoices` mapping each status to brief help text, and a `get_status_description()` method on the `Branch` model that returns the description for the branch's current status.

This is purely additive: no schema change, no migration. It lets consumers (e.g. netbox-changes) surface branch status help text from the canonical source instead of maintaining a parallel description map.

Tests cover forward/reverse completeness of the `DESCRIPTIONS` map and the `get_status_description()` lookup (including the unknown-status fallback).

Blocks `netboxlabs/netbox-changes#176`, which consumes `Branch.get_status_description()` for the branch status tooltip on the change request detail page.
