### PR TITLE
#588 - Preserve unmodified JSON dict keys (e.g. custom_fields) when merging branches

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -43,6 +43,23 @@ class ObjectChange(ObjectChange_):
         for migrator in branch.migrators.get(object_type, []):
             migrator(self, revert)
 
+    def get_merge_data(self, reverse=False):
+        """
+        Build a deletion-aware partial-update payload for replaying this change's UPDATE
+        onto another schema. By default the payload transforms the pre-change state into
+        the post-change state (used by ``apply()``); with ``reverse=True`` it goes the
+        other way (post -> pre), used by ``undo()``.
+
+        This is intentionally separate from ``diff()``: ``diff()`` is display-oriented
+        (rendered in the change-log tables) and represents a removed key as ``None``,
+        whereas merging needs to drop removed nested JSON keys entirely. ``diff_for_merge``
+        tracks those removals with the ``DELETED`` sentinel so ``update_object`` can apply
+        them rather than leave stale ``None`` values behind. (#588, #592)
+        """
+        if reverse:
+            return diff_for_merge(self.postchange_data_clean, self.prechange_data_clean)
+        return diff_for_merge(self.prechange_data_clean, self.postchange_data_clean)
+
     def apply(self, branch, using=DEFAULT_DB_ALIAS, logger=None, skip_missing=False):
         """
         Apply the change using the specified database connection.
@@ -81,10 +98,9 @@ class ObjectChange(ObjectChange_):
             try:
                 instance = model.objects.using(using).get(pk=self.changed_object_id)
                 logger.debug(f'Updating {model._meta.verbose_name} {instance}')
-                # Build a deletion-aware partial-update payload (pre -> post) rather than
-                # using diff()['post'], which cannot represent removed nested JSON keys. (#592)
-                data = diff_for_merge(self.prechange_data_clean, self.postchange_data_clean)
-                update_object(instance, data, using=using)
+                # Use a deletion-aware payload (pre -> post) rather than diff()['post'],
+                # which cannot represent removed nested JSON keys. (#592)
+                update_object(instance, self.get_merge_data(), using=using)
             except model.DoesNotExist:
                 if skip_missing:
                     logger.debug(f'{model._meta.verbose_name} ID {self.changed_object_id} already deleted; skipping')
@@ -126,8 +142,7 @@ class ObjectChange(ObjectChange_):
         elif self.action == ObjectChangeActionChoices.ACTION_UPDATE:
             instance = model.objects.using(using).get(pk=self.changed_object_id)
             # Reverse direction (post -> pre); keys the branch added are removed. (#592)
-            data = diff_for_merge(self.postchange_data_clean, self.prechange_data_clean)
-            update_object(instance, data, using=using)
+            update_object(instance, self.get_merge_data(reverse=True), using=using)
 
         # Restoring a deleted object
         elif self.action == ObjectChangeActionChoices.ACTION_DELETE:

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -14,6 +14,7 @@ from utilities.serialization import deserialize_object
 
 from netbox_branching.utilities import (
     clear_mptt_fields,
+    diff_for_merge,
     full_clean_with_file_check,
     resolve_objectchange_field_migration,
     update_object,
@@ -80,7 +81,10 @@ class ObjectChange(ObjectChange_):
             try:
                 instance = model.objects.using(using).get(pk=self.changed_object_id)
                 logger.debug(f'Updating {model._meta.verbose_name} {instance}')
-                update_object(instance, self.diff()['post'], using=using)
+                # Build a deletion-aware partial-update payload (pre -> post) rather than
+                # using diff()['post'], which cannot represent removed nested JSON keys. (#592)
+                data = diff_for_merge(self.prechange_data_clean, self.postchange_data_clean)
+                update_object(instance, data, using=using)
             except model.DoesNotExist:
                 if skip_missing:
                     logger.debug(f'{model._meta.verbose_name} ID {self.changed_object_id} already deleted; skipping')
@@ -121,7 +125,9 @@ class ObjectChange(ObjectChange_):
         # Reverting a modification to an object
         elif self.action == ObjectChangeActionChoices.ACTION_UPDATE:
             instance = model.objects.using(using).get(pk=self.changed_object_id)
-            update_object(instance, self.diff()['pre'], using=using)
+            # Reverse direction (post -> pre); keys the branch added are removed. (#592)
+            data = diff_for_merge(self.postchange_data_clean, self.prechange_data_clean)
+            update_object(instance, data, using=using)
 
         # Restoring a deleted object
         elif self.action == ObjectChangeActionChoices.ACTION_DELETE:

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -272,18 +272,19 @@ class BaseMergeTests:
 
         branch = self._create_and_provision_branch()
 
-        # In branch: remove the 'f2' key from inside the JSON value
+        # In branch: remove both 'f2' (value '2') and 'f3' (value None). The None-valued
+        # deletion guards the membership check in _diff_for_merge.
         with activate_branch(branch), event_tracking(request):
             site = Site.objects.get(id=site_id)
             site.snapshot()
-            site.custom_field_data['jsoncf'] = {'f1': '1', 'f3': None}
+            site.custom_field_data['jsoncf'] = {'f1': '1'}
             site.save()
 
         branch.merge(user=self.user, commit=True)
 
-        # f2 must be gone — not present as {'f2': None}
+        # f2 and f3 must be gone — not present as {'f2': None, 'f3': None}
         site = Site.objects.get(id=site_id)
-        self.assertEqual(site.custom_field_data['jsoncf'], {'f1': '1', 'f3': None})
+        self.assertEqual(site.custom_field_data['jsoncf'], {'f1': '1'})
 
         # Revert restores the original JSON value, re-adding the deleted key
         branch.revert(user=self.user, commit=True)
@@ -1256,6 +1257,13 @@ class DiffForMergeTests(SimpleTestCase):
         source = {'custom_field_data': {'cf1': {'f1': '1', 'f2': '2', 'f3': None}}}
         dest = {'custom_field_data': {'cf1': {'f1': '1', 'f3': None}}}
         self.assertEqual(diff_for_merge(source, dest), {'custom_field_data': {'cf1': {'f2': DELETED}}})
+
+    def test_diff_nested_deletion_of_none_valued_key(self):
+        # A deleted key is detected by membership even when its value was None, so it
+        # isn't mistaken for "unchanged" by the value-equality check.
+        source = {'cfd': {'f1': '1', 'f3': None}}
+        dest = {'cfd': {'f1': '1'}}
+        self.assertEqual(diff_for_merge(source, dest), {'cfd': {'f3': DELETED}})
 
     def test_diff_reports_additions_and_edits(self):
         # Added/changed nested keys carry their new value; untouched keys are omitted.

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -19,7 +19,7 @@ from dcim.models import (
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import connections
-from django.test import RequestFactory, TransactionTestCase
+from django.test import RequestFactory, SimpleTestCase, TransactionTestCase
 from django.urls import reverse
 from extras.choices import CustomFieldTypeChoices
 from extras.models import CustomField, Tag
@@ -29,7 +29,7 @@ from utilities.exceptions import AbortTransaction
 from netbox_branching.choices import BranchMergeStrategyChoices, BranchStatusChoices
 from netbox_branching.models import Branch, ChangeDiff
 from netbox_branching.tests.utils import provision_branch
-from netbox_branching.utilities import activate_branch
+from netbox_branching.utilities import DELETED, _deep_merge_dict, _strip_deleted, activate_branch, diff_for_merge
 
 User = get_user_model()
 
@@ -290,6 +290,49 @@ class BaseMergeTests:
 
         site = Site.objects.get(id=site_id)
         self.assertEqual(site.custom_field_data['jsoncf'], original)
+
+    def test_merge_removes_deleted_local_context_key(self):
+        """
+        Regression test for #592 covering local_context_data (the "or local context" half of
+        issue #588). Deleting a key from a Device's local_context_data in a branch must remove
+        the key on main when merged, and merging an unrelated key must leave siblings intact.
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In main: create a device with a three-key local context
+        original = {'a': '1', 'b': '2', 'c': None}
+        with event_tracking(request):
+            site = Site.objects.create(name='Site 1', slug='site-1')
+            device = Device.objects.create(
+                name='Device 1',
+                device_type=self.device_type,
+                role=self.device_role,
+                site=site,
+                local_context_data=dict(original),
+            )
+        device_id = device.id
+
+        branch = self._create_and_provision_branch()
+
+        # In branch: remove the 'b' key and add a new 'd' key
+        with activate_branch(branch), event_tracking(request):
+            device = Device.objects.get(id=device_id)
+            device.snapshot()
+            device.local_context_data = {'a': '1', 'c': None, 'd': '4'}
+            device.save()
+
+        branch.merge(user=self.user, commit=True)
+
+        device = Device.objects.get(id=device_id)
+        self.assertEqual(device.local_context_data, {'a': '1', 'c': None, 'd': '4'})
+
+        # Revert restores the original context exactly: 'b' returns and 'd' is dropped
+        branch.revert(user=self.user, commit=True)
+
+        device = Device.objects.get(id=device_id)
+        self.assertEqual(device.local_context_data, original)
 
     def test_merge_basic_delete(self):
         """
@@ -1199,3 +1242,66 @@ class IterativeMergeTestCase(BaseMergeTests, TransactionTestCase):
     """Test cases for Branch merge using iterative merge strategy."""
 
     MERGE_STRATEGY = BranchMergeStrategyChoices.ITERATIVE
+
+
+class DiffForMergeTests(SimpleTestCase):
+    """
+    Unit tests for the deletion-aware diff/merge helpers underpinning JSON-field merges
+    (#588, #592). These exercise the pure functions directly, documenting the contract
+    without the cost of a full branch round-trip.
+    """
+
+    def test_diff_nested_deletion_uses_sentinel(self):
+        # A key removed from inside a nested dict is reported with the DELETED sentinel.
+        source = {'custom_field_data': {'cf1': {'f1': '1', 'f2': '2', 'f3': None}}}
+        dest = {'custom_field_data': {'cf1': {'f1': '1', 'f3': None}}}
+        self.assertEqual(diff_for_merge(source, dest), {'custom_field_data': {'cf1': {'f2': DELETED}}})
+
+    def test_diff_reports_additions_and_edits(self):
+        # Added/changed nested keys carry their new value; untouched keys are omitted.
+        source = {'cfd': {'a': 1, 'b': 2}}
+        dest = {'cfd': {'a': 9, 'b': 2, 'c': 3}}
+        self.assertEqual(diff_for_merge(source, dest), {'cfd': {'a': 9, 'c': 3}})
+
+    def test_diff_top_level_removal_is_none_not_sentinel(self):
+        # Top-level removals flow through setattr, so they stay None rather than a sentinel.
+        delta = diff_for_merge({'a': 1, 'b': 2}, {'a': 1})
+        self.assertEqual(delta, {'b': None})
+        self.assertNotIn(DELETED, delta.values())
+
+    def test_diff_equal_dicts_yield_empty(self):
+        self.assertEqual(diff_for_merge({'cfd': {'a': 1}}, {'cfd': {'a': 1}}), {})
+
+    def test_deep_merge_applies_deletion(self):
+        target = {'cf1': 'main', 'cf2': 'x'}
+        _deep_merge_dict(target, {'cf2': DELETED})
+        self.assertEqual(target, {'cf1': 'main'})
+
+    def test_deep_merge_preserves_untouched_siblings(self):
+        target = {'cf1': 'main-value', 'cf2': 'old'}
+        _deep_merge_dict(target, {'cf2': 'branch-value'})
+        self.assertEqual(target, {'cf1': 'main-value', 'cf2': 'branch-value'})
+
+    def test_deep_merge_deletion_of_absent_key_is_noop(self):
+        target = {'cf1': 'main'}
+        _deep_merge_dict(target, {'cf2': DELETED})
+        self.assertEqual(target, {'cf1': 'main'})
+
+    def test_strip_deleted_removes_sentinels_recursively(self):
+        value = {'a': 1, 'b': DELETED, 'c': {'d': DELETED, 'e': 2}}
+        self.assertEqual(_strip_deleted(value), {'a': 1, 'c': {'e': 2}})
+
+    def test_strip_deleted_passes_through_non_dict(self):
+        self.assertEqual(_strip_deleted('scalar'), 'scalar')
+
+    def test_apply_then_revert_round_trips_nested_dict(self):
+        # apply (pre -> post) deletes a key; revert (post -> pre) restores it exactly.
+        pre = {'cfd': {'cf1': {'f1': '1', 'f2': '2', 'f3': None}}}
+        post = {'cfd': {'cf1': {'f1': '1', 'f3': None}}}
+
+        merged = {'cf1': {'f1': '1', 'f2': '2', 'f3': None}}
+        _deep_merge_dict(merged, diff_for_merge(pre, post)['cfd'])
+        self.assertEqual(merged, {'cf1': {'f1': '1', 'f3': None}})
+
+        _deep_merge_dict(merged, diff_for_merge(post, pre)['cfd'])
+        self.assertEqual(merged, {'cf1': {'f1': '1', 'f2': '2', 'f3': None}})

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -273,7 +273,7 @@ class BaseMergeTests:
         branch = self._create_and_provision_branch()
 
         # In branch: remove both 'f2' (value '2') and 'f3' (value None). The None-valued
-        # deletion guards the membership check in _diff_for_merge.
+        # deletion guards the membership check in diff_for_merge.
         with activate_branch(branch), event_tracking(request):
             site = Site.objects.get(id=site_id)
             site.snapshot()

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -21,6 +21,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import connections
 from django.test import RequestFactory, TransactionTestCase
 from django.urls import reverse
+from extras.choices import CustomFieldTypeChoices
 from extras.models import CustomField, Tag
 from netbox.context_managers import event_tracking
 from utilities.exceptions import AbortTransaction
@@ -231,13 +232,64 @@ class BaseMergeTests:
         site = Site.objects.get(id=site_id)
         self.assertEqual(site.custom_field_data, {'cf1': 'main-value', 'cf2': 'branch-value'})
 
-        # Revert restores cf1 untouched and clears cf2 back to None. (The key remains in
-        # the dict rather than being popped — deep_compare_dict collapses "key absent" and
-        # "key=None" in its output, and for custom_field_data the two are equivalent.)
+        # Revert restores cf1 untouched and removes cf2 entirely. cf2 was never present in
+        # main's pre-branch state, so diff_for_merge() reverses the branch's addition by
+        # dropping the key rather than leaving a stale cf2=None behind. (#592)
         branch.revert(user=self.user, commit=True)
 
         site = Site.objects.get(id=site_id)
-        self.assertEqual(site.custom_field_data, {'cf1': 'main-value', 'cf2': None})
+        self.assertEqual(site.custom_field_data, {'cf1': 'main-value'})
+
+    def test_merge_removes_deleted_nested_json_key(self):
+        """
+        Regression test for #592: deleting a key from inside a JSON field's value (here a
+        JSON-type custom field, but the same applies to local_context_data) must remove the
+        key on the main schema when the branch is merged — not leave it behind as None.
+
+        NetBox's deep_compare_dict reads nested values with dict.get(), so it cannot tell a
+        removed key apart from a key set to None and silently drops the removal from
+        ObjectChange.diff(). diff_for_merge() recovers the removal via key membership and the
+        deep merge drops it, so main matches the branch's intended JSON exactly.
+        """
+        site_ct = ContentType.objects.get_for_model(Site)
+        jsoncf = CustomField.objects.create(
+            name='jsoncf', type=CustomFieldTypeChoices.TYPE_JSON, required=False
+        )
+        jsoncf.object_types.set([site_ct])
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In main: create site and set the JSON custom field to a three-key object
+        original = {'f1': '1', 'f2': '2', 'f3': None}
+        with event_tracking(request):
+            site = Site.objects.create(name='Site 1', slug='site-1')
+            site.snapshot()
+            site.custom_field_data['jsoncf'] = dict(original)
+            site.save()
+        site_id = site.id
+
+        branch = self._create_and_provision_branch()
+
+        # In branch: remove the 'f2' key from inside the JSON value
+        with activate_branch(branch), event_tracking(request):
+            site = Site.objects.get(id=site_id)
+            site.snapshot()
+            site.custom_field_data['jsoncf'] = {'f1': '1', 'f3': None}
+            site.save()
+
+        branch.merge(user=self.user, commit=True)
+
+        # f2 must be gone — not present as {'f2': None}
+        site = Site.objects.get(id=site_id)
+        self.assertEqual(site.custom_field_data['jsoncf'], {'f1': '1', 'f3': None})
+
+        # Revert restores the original JSON value, re-adding the deleted key
+        branch.revert(user=self.user, commit=True)
+
+        site = Site.objects.get(id=site_id)
+        self.assertEqual(site.custom_field_data['jsoncf'], original)
 
     def test_merge_basic_delete(self):
         """

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1295,6 +1295,21 @@ class DiffForMergeTests(SimpleTestCase):
         _deep_merge_dict(target, {'cf2': DELETED})
         self.assertEqual(target, {'cf1': 'main'})
 
+    def test_deep_merge_strips_sentinel_when_target_slot_not_dict(self):
+        # When the incoming value is a sentinel-bearing dict but the target slot is not a
+        # dict (None here — common for local_context_data), the merge can't recurse. The
+        # DELETED marker must be stripped rather than written verbatim, since a _DeletedKey
+        # is not JSON-serializable and would crash on save().
+        target = {'jsoncf': None}
+        _deep_merge_dict(target, {'jsoncf': {'f1': '1', 'f2': DELETED}})
+        self.assertEqual(target, {'jsoncf': {'f1': '1'}})
+
+    def test_deep_merge_strips_sentinel_when_target_key_missing(self):
+        # Same as above, but the target slot is entirely absent.
+        target = {}
+        _deep_merge_dict(target, {'jsoncf': {'f1': '1', 'f2': DELETED}})
+        self.assertEqual(target, {'jsoncf': {'f1': '1'}})
+
     def test_strip_deleted_removes_sentinels_recursively(self):
         value = {'a': 1, 'b': DELETED, 'c': {'d': DELETED, 'e': 2}}
         self.assertEqual(_strip_deleted(value), {'a': 1, 'c': {'e': 2}})

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -21,7 +21,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import connections
 from django.test import RequestFactory, TransactionTestCase
 from django.urls import reverse
-from extras.models import Tag
+from extras.models import CustomField, Tag
 from netbox.context_managers import event_tracking
 from utilities.exceptions import AbortTransaction
 
@@ -187,6 +187,57 @@ class BaseMergeTests:
         # Verify site is restored to original state after revert
         site = Site.objects.get(id=site_id)
         self.assertEqual(site.description, original_description)
+
+    def test_merge_preserves_unmodified_custom_fields(self):
+        """
+        Regression test for #588: a branch that modifies one custom field must not
+        wipe out other custom fields that were set in main before the branch.
+
+        NetBox 4.6 (PR #21691) switched ObjectChange.diff() to use deep_compare_dict,
+        which returns only the changed keys within nested dicts. Without a merge in
+        update_object(), applying that partial dict via setattr replaces the entire
+        custom_field_data on the main schema and unrelated custom fields disappear.
+        """
+        site_ct = ContentType.objects.get_for_model(Site)
+        cf1 = CustomField.objects.create(name='cf1', required=False)
+        cf1.object_types.set([site_ct])
+        cf2 = CustomField.objects.create(name='cf2', required=False)
+        cf2.object_types.set([site_ct])
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In main: create site and set cf1
+        with event_tracking(request):
+            site = Site.objects.create(name='Site 1', slug='site-1')
+            site.snapshot()
+            site.custom_field_data['cf1'] = 'main-value'
+            site.save()
+        site_id = site.id
+
+        # Create branch (snapshots main state including cf1='main-value')
+        branch = self._create_and_provision_branch()
+
+        # In branch: set cf2 only — should leave cf1 untouched on merge
+        with activate_branch(branch), event_tracking(request):
+            site = Site.objects.get(id=site_id)
+            site.snapshot()
+            site.custom_field_data['cf2'] = 'branch-value'
+            site.save()
+
+        branch.merge(user=self.user, commit=True)
+
+        site = Site.objects.get(id=site_id)
+        self.assertEqual(site.custom_field_data.get('cf1'), 'main-value')
+        self.assertEqual(site.custom_field_data.get('cf2'), 'branch-value')
+
+        # Revert should drop cf2 but keep cf1
+        branch.revert(user=self.user, commit=True)
+
+        site = Site.objects.get(id=site_id)
+        self.assertEqual(site.custom_field_data.get('cf1'), 'main-value')
+        self.assertIsNone(site.custom_field_data.get('cf2'))
 
     def test_merge_basic_delete(self):
         """

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -229,15 +229,15 @@ class BaseMergeTests:
         branch.merge(user=self.user, commit=True)
 
         site = Site.objects.get(id=site_id)
-        self.assertEqual(site.custom_field_data.get('cf1'), 'main-value')
-        self.assertEqual(site.custom_field_data.get('cf2'), 'branch-value')
+        self.assertEqual(site.custom_field_data, {'cf1': 'main-value', 'cf2': 'branch-value'})
 
-        # Revert should drop cf2 but keep cf1
+        # Revert restores cf1 untouched and clears cf2 back to None. (The key remains in
+        # the dict rather than being popped — deep_compare_dict collapses "key absent" and
+        # "key=None" in its output, and for custom_field_data the two are equivalent.)
         branch.revert(user=self.user, commit=True)
 
         site = Site.objects.get(id=site_id)
-        self.assertEqual(site.custom_field_data.get('cf1'), 'main-value')
-        self.assertIsNone(site.custom_field_data.get('cf2'))
+        self.assertEqual(site.custom_field_data, {'cf1': 'main-value', 'cf2': None})
 
     def test_merge_basic_delete(self):
         """

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -391,14 +391,20 @@ def diff_for_merge(source, destination):
 def _diff_for_merge(source, destination, top_level=False):
     delta = {}
     for key in sorted(source.keys() | destination.keys()):
+        in_source = key in source
+        in_destination = key in destination
         src_val = source.get(key)
         dst_val = destination.get(key)
-        if src_val == dst_val:
+        if in_source and in_destination and src_val == dst_val:
+            # Key present on both sides with an identical value — unchanged.
             continue
         if isinstance(src_val, dict) and isinstance(dst_val, dict):
             # Recurse; unequal dicts always yield at least one nested change.
             delta[key] = _diff_for_merge(src_val, dst_val)
-        elif key not in destination and not top_level:
+        elif not in_destination and not top_level:
+            # Removed from a nested dict. Detected via key membership, not value
+            # equality, so a key whose value was None is still recognised as a
+            # deletion rather than treated as unchanged.
             delta[key] = DELETED
         else:
             delta[key] = dst_val

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 _branch_connections_tracker = Local(thread_critical=False)
 
 __all__ = (
+    'DELETED',
     'ActiveBranchContextManager',
     'BranchActionIndicator',
     'ChangeSummary',
@@ -44,6 +45,7 @@ __all__ = (
     'clear_mptt_fields',
     'close_old_branch_connections',
     'deactivate_branch',
+    'diff_for_merge',
     'full_clean_with_file_check',
     'get_active_branch',
     'get_branchable_object_types',
@@ -365,7 +367,7 @@ class _DeletedKey:
 DELETED = _DeletedKey()
 
 
-def diff_for_merge(source, destination):
+def diff_for_merge(source, destination, top_level=True):
     """
     Compute the partial-update payload that transforms ``source`` into ``destination``
     when deep-merged onto a target via ``update_object`` / ``_deep_merge_dict``.
@@ -383,12 +385,10 @@ def diff_for_merge(source, destination):
     after a merge or revert. Tracking removals explicitly lets the merge drop them. (#592)
 
     Top-level removals are represented with the value ``None`` (matching prior behaviour),
-    since those flow through ``setattr`` rather than a deep merge.
+    since those flow through ``setattr`` rather than a deep merge; nested removals use the
+    ``DELETED`` sentinel. ``top_level`` distinguishes the two and is set to ``False`` on
+    the recursive calls — callers should not pass it.
     """
-    return _diff_for_merge(source, destination, top_level=True)
-
-
-def _diff_for_merge(source, destination, top_level=False):
     delta = {}
     for key in sorted(source.keys() | destination.keys()):
         in_source = key in source
@@ -400,7 +400,7 @@ def _diff_for_merge(source, destination, top_level=False):
             continue
         if isinstance(src_val, dict) and isinstance(dst_val, dict):
             # Recurse; unequal dicts always yield at least one nested change.
-            delta[key] = _diff_for_merge(src_val, dst_val)
+            delta[key] = diff_for_merge(src_val, dst_val, top_level=False)
         elif not in_destination and not top_level:
             # Removed from a nested dict. Detected via key membership, not value
             # equality, so a key whose value was None is still recognised as a

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -350,6 +350,19 @@ def clear_mptt_fields(instance):
         setattr(instance, attr, None)
 
 
+def _deep_merge_dict(target, source):
+    """
+    Recursively merge ``source`` into ``target`` in place. Nested dicts are
+    merged key-by-key; all other values are replaced.
+    """
+    for key, value in source.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_merge_dict(target[key], value)
+        else:
+            target[key] = value
+    return target
+
+
 def update_object(instance, data, using):
     """
     Set an attribute on an object depending on the type of model field.
@@ -388,6 +401,12 @@ def update_object(instance, data, using):
             # Use M2M manager for ManyToMany assignments
             m2m_manager = getattr(instance, attr)
             m2m_assignments[m2m_manager] = value
+        elif isinstance(value, dict) and isinstance(getattr(instance, attr, None), dict):
+            # ObjectChange.diff() (NetBox 4.6+, PR #21691) uses deep_compare_dict, so JSON
+            # fields like custom_field_data and local_context_data arrive as partial dicts
+            # containing only the keys the change touched. Merge into the existing dict so
+            # keys the branch never modified are preserved on the target schema. (#588)
+            _deep_merge_dict(getattr(instance, attr), value)
         else:
             setattr(instance, attr, value)
 

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -434,7 +434,11 @@ def _deep_merge_dict(target, source):
         elif isinstance(value, dict) and isinstance(target.get(key), dict):
             _deep_merge_dict(target[key], value)
         else:
-            target[key] = value
+            # No dict to merge into (target slot is None/scalar/missing). Strip any
+            # nested DELETED sentinels so they never reach the field — a _DeletedKey
+            # is not JSON-serializable and would crash on save(). _strip_deleted is a
+            # no-op on non-dicts, so this is safe for all values.
+            target[key] = _strip_deleted(value)
     return target
 
 

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -44,7 +44,6 @@ __all__ = (
     'clear_mptt_fields',
     'close_old_branch_connections',
     'deactivate_branch',
-    'diff_for_merge',
     'full_clean_with_file_check',
     'get_active_branch',
     'get_branchable_object_types',

--- a/netbox_branching/utilities.py
+++ b/netbox_branching/utilities.py
@@ -44,6 +44,7 @@ __all__ = (
     'clear_mptt_fields',
     'close_old_branch_connections',
     'deactivate_branch',
+    'diff_for_merge',
     'full_clean_with_file_check',
     'get_active_branch',
     'get_branchable_object_types',
@@ -350,13 +351,82 @@ def clear_mptt_fields(instance):
         setattr(instance, attr, None)
 
 
+class _DeletedKey:
+    """
+    Sentinel marking a dict key that should be removed (rather than set to None)
+    during a deep merge. See ``diff_for_merge``.
+    """
+    __slots__ = ()
+
+    def __repr__(self):
+        return '<DELETED>'
+
+
+# Singleton sentinel instance, compared by identity.
+DELETED = _DeletedKey()
+
+
+def diff_for_merge(source, destination):
+    """
+    Compute the partial-update payload that transforms ``source`` into ``destination``
+    when deep-merged onto a target via ``update_object`` / ``_deep_merge_dict``.
+
+    This mirrors the "added" side of NetBox's ``deep_compare_dict`` — only differing
+    keys are returned, and nested dicts yield only their changed keys so that keys the
+    branch never touched are preserved on the target schema (#588) — with one critical
+    difference: a key present in ``source`` but absent from ``destination`` *within a
+    nested dict* is represented with the ``DELETED`` sentinel instead of being dropped.
+
+    ``deep_compare_dict`` reads nested values with ``dict.get()``, so it cannot tell
+    "key removed" apart from "key set to None" and silently omits removals. Replaying
+    that diff would leave stale keys behind inside JSON fields (e.g. a key deleted from
+    a JSON custom field's value, or from ``local_context_data``) on the main schema
+    after a merge or revert. Tracking removals explicitly lets the merge drop them. (#592)
+
+    Top-level removals are represented with the value ``None`` (matching prior behaviour),
+    since those flow through ``setattr`` rather than a deep merge.
+    """
+    return _diff_for_merge(source, destination, top_level=True)
+
+
+def _diff_for_merge(source, destination, top_level=False):
+    delta = {}
+    for key in sorted(source.keys() | destination.keys()):
+        src_val = source.get(key)
+        dst_val = destination.get(key)
+        if src_val == dst_val:
+            continue
+        if isinstance(src_val, dict) and isinstance(dst_val, dict):
+            # Recurse; unequal dicts always yield at least one nested change.
+            delta[key] = _diff_for_merge(src_val, dst_val)
+        elif key not in destination and not top_level:
+            delta[key] = DELETED
+        else:
+            delta[key] = dst_val
+    return delta
+
+
+def _strip_deleted(value):
+    """
+    Return a copy of ``value`` with any ``DELETED``-sentinel keys removed (recursively).
+    Used when a partial JSON update has no existing dict to merge into, so deletion
+    markers must simply be dropped rather than written to the field.
+    """
+    if not isinstance(value, dict):
+        return value
+    return {k: _strip_deleted(v) for k, v in value.items() if v is not DELETED}
+
+
 def _deep_merge_dict(target, source):
     """
     Recursively merge ``source`` into ``target`` in place. Nested dicts are
-    merged key-by-key; all other values are replaced.
+    merged key-by-key; the ``DELETED`` sentinel removes the key from ``target``;
+    all other values are replaced.
     """
     for key, value in source.items():
-        if isinstance(value, dict) and isinstance(target.get(key), dict):
+        if value is DELETED:
+            target.pop(key, None)
+        elif isinstance(value, dict) and isinstance(target.get(key), dict):
             _deep_merge_dict(target[key], value)
         else:
             target[key] = value
@@ -401,12 +471,19 @@ def update_object(instance, data, using):
             # Use M2M manager for ManyToMany assignments
             m2m_manager = getattr(instance, attr)
             m2m_assignments[m2m_manager] = value
-        elif isinstance(value, dict) and isinstance(getattr(instance, attr, None), dict):
-            # ObjectChange.diff() (NetBox 4.6+, PR #21691) uses deep_compare_dict, so JSON
-            # fields like custom_field_data and local_context_data arrive as partial dicts
-            # containing only the keys the change touched. Merge into the existing dict so
-            # keys the branch never modified are preserved on the target schema. (#588)
-            _deep_merge_dict(getattr(instance, attr), value)
+        elif isinstance(value, dict):
+            # JSON fields like custom_field_data and local_context_data arrive as partial
+            # dicts (via diff_for_merge) containing only the keys the change touched, with
+            # removed keys carrying the DELETED sentinel. Merge into the existing dict so
+            # keys the branch never modified are preserved on the target schema (#588) and
+            # removed keys are dropped (#592). If there's no dict to merge into, materialize
+            # the partial dict, discarding deletion markers so the sentinel never reaches
+            # the field.
+            current = getattr(instance, attr, None)
+            if isinstance(current, dict):
+                _deep_merge_dict(current, value)
+            else:
+                setattr(instance, attr, _strip_deleted(value))
         else:
             setattr(instance, attr, value)
 


### PR DESCRIPTION
### Fixes: #588 

NetBox 4.6 (PR #21691) changed ObjectChange.diff() to use deep_compare_dict, so JSON fields like custom_field_data now arrive as partial dicts containing only the keys that changed. update_object() was still setattr-ing those partial dicts, wiping out keys the branch never touched (e.g. setting cf2 in a branch erased cf1 on merge).

Fix is to deep-merge incoming dicts into the existing attribute instead of replacing them.
