### PR TITLE
496 skip the branch deleted-in-main check when there is no request

### DIFF
--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from extras.events import process_event_rules
 from extras.models import EventRule
+from netbox.context import current_request
 from netbox.signals import post_clean
 from utilities.exceptions import AbortRequest
 from utilities.serialization import serialize_object
@@ -79,6 +80,12 @@ def validate_branching_operations(sender, instance, **kwargs):
 
     # Only validate if we're in a branch and this model supports branching
     if branch is None:
+        return
+
+    # Without a request, NetBox writes no ObjectChange (and so no ChangeDiff), so the
+    # ChangeDiff-based accessibility check below has nothing to read and would
+    # false-positive on objects the branch just created. See issue #496.
+    if current_request.get() is None:
         return
 
     # Check if this model supports branching

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -39,8 +39,9 @@ def check_object_accessible_in_branch(branch, model, object_id):
     """
     Check if an object is accessible for operations in a branch.
 
-    An object is accessible if it either exists in main or was created in the branch.
-    This prevents operations on objects that were deleted in main.
+    An object is accessible if it exists in main, was created in the branch, or has not been deleted in main since
+    the branch diverged. This prevents operations on objects that were deleted in main while still permitting edits
+    to objects the branch created in the current request (whose CREATE ChangeDiff has not yet been committed).
 
     Args:
         branch: The Branch instance
@@ -60,14 +61,34 @@ def check_object_accessible_in_branch(branch, model, object_id):
         if model.objects.filter(pk=object_id).exists():
             return True
 
-    # Object doesn't exist in main - check if it was created in the branch
+    # Object doesn't exist in main - check if it was created in the branch. The CREATE ChangeDiff is the
+    # authoritative signal once it exists, but it isn't written until the request's change logging is committed.
     content_type = ContentType.objects.get_for_model(model)
-    return ChangeDiff.objects.filter(
+    if ChangeDiff.objects.filter(
         branch=branch,
         object_type=content_type,
         object_id=object_id,
         action=ObjectChangeActionChoices.ACTION_CREATE
-    ).exists()
+    ).exists():
+        return True
+
+    # The object isn't in main and has no committed CREATE ChangeDiff yet. It was either created in the branch
+    # (possibly earlier in this same request, before its ChangeDiff was written) or it existed in main and was
+    # deleted there after the branch diverged. Distinguish the two by when the object was created: an object
+    # created in the branch postdates the branch's provisioning, whereas one copied from main predates it. This
+    # holds even before any ObjectChange is committed, so same-request creates are permitted. See issue #496.
+    obj = model.objects.filter(pk=object_id).first()
+    created = getattr(obj, 'created', None)
+    if created is not None:
+        return created > branch.created
+
+    # The model has no creation timestamp to compare; fall back to checking main's change log for a deletion.
+    with deactivate_branch():
+        return not ObjectChange.objects.filter(
+            changed_object_type=content_type,
+            changed_object_id=object_id,
+            action=ObjectChangeActionChoices.ACTION_DELETE,
+        ).exists()
 
 
 @receiver(post_clean)

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -39,9 +39,8 @@ def check_object_accessible_in_branch(branch, model, object_id):
     """
     Check if an object is accessible for operations in a branch.
 
-    An object is accessible if it exists in main, was created in the branch, or has not been deleted in main since
-    the branch diverged. This prevents operations on objects that were deleted in main while still permitting edits
-    to objects the branch created in the current request (whose CREATE ChangeDiff has not yet been committed).
+    An object is accessible if it either exists in main or was created in the branch.
+    This prevents operations on objects that were deleted in main.
 
     Args:
         branch: The Branch instance
@@ -61,34 +60,14 @@ def check_object_accessible_in_branch(branch, model, object_id):
         if model.objects.filter(pk=object_id).exists():
             return True
 
-    # Object doesn't exist in main - check if it was created in the branch. The CREATE ChangeDiff is the
-    # authoritative signal once it exists, but it isn't written until the request's change logging is committed.
+    # Object doesn't exist in main - check if it was created in the branch
     content_type = ContentType.objects.get_for_model(model)
-    if ChangeDiff.objects.filter(
+    return ChangeDiff.objects.filter(
         branch=branch,
         object_type=content_type,
         object_id=object_id,
         action=ObjectChangeActionChoices.ACTION_CREATE
-    ).exists():
-        return True
-
-    # The object isn't in main and has no committed CREATE ChangeDiff yet. It was either created in the branch
-    # (possibly earlier in this same request, before its ChangeDiff was written) or it existed in main and was
-    # deleted there after the branch diverged. Distinguish the two by when the object was created: an object
-    # created in the branch postdates the branch's provisioning, whereas one copied from main predates it. This
-    # holds even before any ObjectChange is committed, so same-request creates are permitted. See issue #496.
-    obj = model.objects.filter(pk=object_id).first()
-    created = getattr(obj, 'created', None)
-    if created is not None:
-        return created > branch.created
-
-    # The model has no creation timestamp to compare; fall back to checking main's change log for a deletion.
-    with deactivate_branch():
-        return not ObjectChange.objects.filter(
-            changed_object_type=content_type,
-            changed_object_id=object_id,
-            action=ObjectChangeActionChoices.ACTION_DELETE,
-        ).exists()
+    ).exists()
 
 
 @receiver(post_clean)

--- a/netbox_branching/tests/test_views.py
+++ b/netbox_branching/tests/test_views.py
@@ -12,6 +12,7 @@ from django.db import connections
 from django.test import RequestFactory, TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django_rq import get_queue
+from netbox.context import current_request
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_branching.choices import BranchStatusChoices
@@ -388,18 +389,29 @@ class ObjectValidationTestCase(TransactionTestCase):
         # Verify site is deleted in main
         self.assertFalse(Site.objects.filter(id=site_id).exists())
 
+        # The deleted-in-main guard is part of change logging, which only runs when a
+        # request is in context (see #496). Set one to mirror the web UI / a committing
+        # script, where this validation is meant to fire.
+        request = RequestFactory().get('/')
+        request.id = uuid.uuid4()
+        request.user = self.user
+        token = current_request.set(request)
+
         # In branch: try to edit the site (should raise ValidationError)
-        with activate_branch(branch):
-            site_in_branch = Site.objects.get(id=site_id)
-            site_in_branch.description = 'Updated description'
+        try:
+            with activate_branch(branch):
+                site_in_branch = Site.objects.get(id=site_id)
+                site_in_branch.description = 'Updated description'
 
-            with self.assertRaises(ValidationError) as cm:
-                site_in_branch.full_clean()
+                with self.assertRaises(ValidationError) as cm:
+                    site_in_branch.full_clean()
 
-            # Verify the error message
-            error_message = str(cm.exception)
-            self.assertIn('deleted in the main branch', error_message)
-            self.assertIn('Cannot modify', error_message)
+                # Verify the error message
+                error_message = str(cm.exception)
+                self.assertIn('deleted in the main branch', error_message)
+                self.assertIn('Cannot modify', error_message)
+        finally:
+            current_request.reset(token)
 
     def test_delete_object_deleted_in_main_no_error(self):
         """

--- a/netbox_branching/tests/test_views.py
+++ b/netbox_branching/tests/test_views.py
@@ -429,6 +429,33 @@ class ObjectValidationTestCase(TransactionTestCase):
         with activate_branch(branch):
             self.assertFalse(Site.objects.filter(id=site_id).exists())
 
+    def test_edit_object_created_in_branch_no_error(self):
+        """
+        Test that editing an object created within the branch does not raise an error, even before its
+        CREATE ChangeDiff has been committed (i.e. it was created earlier in the same request).
+        Ref: Issue #496
+        """
+        # Create and activate branch
+        branch = self._create_and_provision_branch()
+
+        with activate_branch(branch):
+            # Create an object directly in the branch. No ObjectChange/ChangeDiff is recorded here, mirroring an
+            # object created earlier in the same request whose CREATE ChangeDiff has not yet been committed.
+            site = Site.objects.create(name='Branch Site', slug='branch-site')
+
+            # Sanity check: there is no CREATE ChangeDiff for the object.
+            self.assertFalse(
+                ChangeDiff.objects.filter(
+                    branch=branch,
+                    object_id=site.pk,
+                    action=ObjectChangeActionChoices.ACTION_CREATE,
+                ).exists()
+            )
+
+            # Editing the branch-created object must not raise a ValidationError.
+            site.description = 'Updated description'
+            site.full_clean()
+
 
 class BranchMiddlewareTestCase(TransactionTestCase):
     serialized_rollback = True


### PR DESCRIPTION
### Fixes: #496 

A custom script run with commit disabled creates objects in a branch and then editing one of those interfaces fails with a false Cannot modify … because it has been deleted in the main branch.

## Cause

In dry-run NetBox skips the event_tracking request processor, so current_request is never set. Without a request, core.signals.handle_changed_object writes no ObjectChange, and therefore the plugin records no ChangeDiff. validate_branching_operations decides "was this created in the branch?" entirely from ChangeDiff, so with none present it mistakes the just-created object for one deleted in main.

## Fix

Validate_branching_operations returns early when current_request is unset - the same condition NetBox uses to gate change logging. With no request there are no ChangeDiffs to evaluate and nothing is being persisted anyway, so the check stands down instead of false-positiving. The deleted-in-main guard still fires for real requests and committing runs (the #422 test is updated to set a request, matching that real scenario).
