### PR TITLE
#581 - Close branch connections during post-migrate pending-migrations check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v1.0.5
+
+### Bug Fixes
+
+* [#581](https://github.com/netboxlabs/netbox-branching/issues/581) - Close each branch's database connection during the post-migrate pending-migrations check to avoid leaking Postgres backends (and exhausting memory/connections) with many open branches
+
+---
+
 ## v1.0.4
 
 ### Enhancements

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,5 @@
 # Change Log
 
-## v1.0.5
-
-### Bug Fixes
-
-* [#581](https://github.com/netboxlabs/netbox-branching/issues/581) - Close each branch's database connection during the post-migrate pending-migrations check to avoid leaking Postgres backends (and exhausting memory/connections) with many open branches
-
----
-
 ## v1.0.4
 
 ### Enhancements

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -291,6 +291,8 @@ def check_pending_migrations(sender, using, **kwargs):
             if branch.pending_migrations:
                 branch.status = BranchStatusChoices.PENDING_MIGRATIONS
                 update_count += 1
+        except Exception:
+            logger.exception(f"Failed to check pending migrations for branch {branch!r}")
         finally:
             # Close the branch's database connection to release its Postgres backend (and the relcache memory
             # accumulated by the pending_migrations introspection) before moving on. Otherwise these connections

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -6,7 +6,7 @@ from core.models import ObjectChange, ObjectType
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import DEFAULT_DB_ALIAS
+from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.models.signals import post_migrate, post_save, pre_delete
 from django.dispatch import receiver
 from django.utils import timezone
@@ -287,9 +287,16 @@ def check_pending_migrations(sender, using, **kwargs):
     open_branches = Branch.objects.filter(status=BranchStatusChoices.READY)
     update_count = 0
     for branch in open_branches:
-        if branch.pending_migrations:
-            branch.status = BranchStatusChoices.PENDING_MIGRATIONS
-            update_count += 1
+        try:
+            if branch.pending_migrations:
+                branch.status = BranchStatusChoices.PENDING_MIGRATIONS
+                update_count += 1
+        finally:
+            # Close the branch's database connection to release its Postgres backend (and the relcache memory
+            # accumulated by the pending_migrations introspection) before moving on. Otherwise these connections
+            # leak across the loop, since close_old_branch_connections() only fires on request signals and this
+            # sweep runs under `manage.py migrate`. See issue #581.
+            connections[branch.connection_name].close()
     if update_count:
         logger.info(f"Updating status of {update_count} branches with pending migrations")
         Branch.objects.bulk_update(open_branches, ['status'], batch_size=100)

--- a/netbox_branching/tests/test_connection_lifecycle.py
+++ b/netbox_branching/tests/test_connection_lifecycle.py
@@ -1,11 +1,13 @@
 import time
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db import connections
+from django.db import DEFAULT_DB_ALIAS, connections
 from django.test import TransactionTestCase, tag
 
 from netbox_branching.models import Branch
+from netbox_branching.signal_receivers import check_pending_migrations
 from netbox_branching.utilities import activate_branch, close_old_branch_connections
 
 
@@ -74,6 +76,27 @@ class BranchConnectionLifecycleTestCase(TransactionTestCase):
 
         for i, conn in enumerate(conns):
             self.assertIsNone(conn.connection, f"Branch {i} connection should be closed")
+
+    def test_check_pending_migrations_closes_branch_connections(self):
+        """check_pending_migrations should close each branch's connection after inspecting it (#581)."""
+        branches = [self.create_and_provision_branch(f'test-pending-{i}') for i in range(3)]
+
+        # Open each branch connection so we can verify the sweep closes it.
+        for branch in branches:
+            self.open_branch_connection(branch)
+        for branch in branches:
+            self.assertIsNotNone(
+                connections[branch.connection_name].connection, "Connection should be open before the sweep"
+            )
+
+        # Fire the post_migrate handler as Django would during `manage.py migrate`.
+        check_pending_migrations(sender=apps.get_app_config('netbox_branching'), using=DEFAULT_DB_ALIAS)
+
+        for branch in branches:
+            self.assertIsNone(
+                connections[branch.connection_name].connection,
+                "Branch connection should be closed after check_pending_migrations",
+            )
 
     def test_cleanup_handles_deleted_branch(self):
         """Cleanup should gracefully handle connections to deleted branch schemas."""


### PR DESCRIPTION
### Fixes: #581 

The `post_migrate` handler `check_pending_migrations` opens each READY branch's connection to check for pending migrations but never closed them, leaking connections and relcache memory during `manage.py migrate` (where `close_old_branch_connections()` doesn't fire). This closes each branch connection right after inspecting it, with a regression test covering the cleanup.