### PR TITLE
#114 - remove notes regarding plugin ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ source /opt/netbox/venv/bin/activate
 $ pip install netboxlabs-netbox-branching
 ```
 
-4. Add `netbox_branching` to the end of `PLUGINS` in `configuration.py`. Note that `netbox_branching` **MUST** be the last plugin listed.
+4. Add `netbox_branching` to `PLUGINS` in `configuration.py`.
 
 ```python
 PLUGINS = [

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ pip install netboxlabs-netbox-branching
 
 ### 4. Enable Plugin
 
-Add `netbox_branching` to **the end** of the `PLUGINS` list in `configuration.py`.
+Add `netbox_branching` to the `PLUGINS` list in `configuration.py`.
 
 ```python
 PLUGINS = [
@@ -120,9 +120,6 @@ PLUGINS = [
     'netbox_branching',
 ]
 ```
-
-!!! warning
-    `netbox_branching` must be the **last** (or only) plugin in the list. Branching support will not be registered for models provided by any plugin appearing later in the list.
 
 !!! note
     If there are no plugins already installed, you might need to create this parameter. If so, be sure to define `PLUGINS` as a list _containing_ the plugin name as above, rather than just the name.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -305,20 +305,6 @@ Use this only when the default heuristic would incorrectly fake a migration that
 
 Pure schema migrations (`AddField`, `AlterField`, etc.) on branchable models don't need the flag — the heuristic handles them correctly by running them on every branch.
 
-## Plugin Installation Order
-
-!!! warning
-    `netbox_branching` must be listed **last** in the `PLUGINS` configuration. Branching support is only registered for models provided by plugins that appear **before** it in the list.
-
-    ```python
-    PLUGINS = [
-        'my_plugin',          # branching support registered for my_plugin's models
-        'netbox_branching',   # must be last
-    ]
-    ```
-
-    Any plugin listed after `netbox_branching` will not have its models enrolled in branching support.
-
 ## Branches and Plugin Upgrades
 
 If a plugin is installed or upgraded after branches have been created, the existing branch schemas will **not** automatically receive the new database migrations. Branches with outstanding migrations will be flagged with the **Pending Migrations** status and can be brought up to date using the **Migrate** action; until they are migrated, they cannot be activated or merged.


### PR DESCRIPTION
### Fixes: #114 

Branching support is no longer sensitive to where netbox_branching appears in the PLUGINS list. This was originally fixed in code by #320, which adopted NetBox 4.4's register_model_feature - branching is now registered as a lazy callable (supports_branching) that NetBox evaluates on demand (per query in BranchAwareRouter, and per model when ObjectType.features is rebuilt in the post_migrate handler that runs after every plugin's ready()), rather than by enumerating models at startup.

This PR cleans up the leftover docs.
