### PR TITLE
Add django_apps configuration for PostgreSQL support

### DIFF
--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -49,6 +49,7 @@ class AppConfig(PluginConfig):
         # Number of days before staleness at which to display a stale warning
         'stale_warning_threshold': 7,
     }
+    django_apps = ["django.contrib.postgres"]
 
     def ready(self):
         super().ready()


### PR DESCRIPTION
Fix issue:

"django.contrib.postgres" not found in INSTALLED_APPS

when running "manage.py check"

- Netbox v4.4.9
- Netbox Docker 3.4.2

I have no idea why I have to add this line but it fixed our issue.