### PR TITLE
603 - remove unpinned django dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
 ]
 
-dependencies = [
-    "Django",
-]
+dependencies = []
 
 [project.optional-dependencies]
 dev = ["check-manifest", "mkdocs", "mkdocs-material", "ruff==0.15.2"]


### PR DESCRIPTION
### Fixes: #603 

Unpinned Django dependency (which isn't needed) causes problems when installing via uv without --nodeps flag.