### PR TITLE
#608 - Generalize squash merge cycle breaking to FK cycles of any length

### DIFF
--- a/netbox_branching/merge_strategies/squash.py
+++ b/netbox_branching/merge_strategies/squash.py
@@ -499,6 +499,11 @@ class SquashMergeStrategy(MergeStrategy):
             if color[start] != WHITE:
                 continue
             color[start] = GRAY
+            # Each stack frame stores a *live iterator* over a node's neighbours, not the
+            # neighbour list. Revisiting a frame resumes that iterator where it left off
+            # (Python iterators return self from __iter__), which is what lets DFS continue
+            # past an already-explored child. Do not replace iter(...) with the list itself
+            # or copy the frame's iterator — either would restart the scan and break the DFS.
             stack = [(start, iter(adjacency[start]))]
             while stack:
                 node, neighbors = stack[-1]
@@ -528,7 +533,7 @@ class SquashMergeStrategy(MergeStrategy):
         return None
 
     @staticmethod
-    def _defer_fk(collapsed_changes, create, field_name, logger):
+    def _defer_fk(collapsed_changes, create, field_name):
         """
         Break a cycle at ``create``'s nullable FK ``field_name`` by NULLing it on the CREATE
         and emitting a synthetic follow-up UPDATE that restores the original value once the
@@ -545,13 +550,25 @@ class SquashMergeStrategy(MergeStrategy):
         original_postchange = dict(create.postchange_data)
         create.postchange_data[field_name] = None
 
+        # 3-tuple keys distinguish synthetic UPDATEs from real (2-tuple) changes; assert the
+        # contract so a future 3-tuple key elsewhere can't silently overwrite a real change.
         update_key = (create.key[0], create.key[1], f'update_{field_name}')
+        assert update_key not in collapsed_changes, f"Unexpected key collision: {update_key}"
+
         update_collapsed = CollapsedChange(update_key, create.model_class)
         update_collapsed.change_count = 1  # Synthetic update from split
         update_collapsed.final_action = ActionType.UPDATE
         update_collapsed.prechange_data = dict(create.postchange_data)
         update_collapsed.postchange_data = original_postchange
         update_collapsed.last_change = create.last_change
+
+        # The UPDATE depends on the originating CREATE existing first. That ordering is also
+        # enforced transitively through the cycle (the FK target leads back to this object),
+        # but make it direct so _defer_fk doesn't rely on that implicit precondition.
+        # _build_fk_dependency_graph runs afterwards and only adds to these sets, so the
+        # manual edge survives.
+        update_collapsed.depends_on.add(create.key)
+        create.depended_by.add(update_key)
 
         collapsed_changes[update_key] = update_collapsed
 
@@ -614,7 +631,7 @@ class SquashMergeStrategy(MergeStrategy):
                             f".{field_name} -> {creates[dst].model_class.__name__}:{dst[1]} "
                             f"(cycle length {len(cycle)})"
                         )
-                        SquashMergeStrategy._defer_fk(collapsed_changes, creates[src], field_name, logger)
+                        SquashMergeStrategy._defer_fk(collapsed_changes, creates[src], field_name)
                         broken_fields.add((src, field_name))
                         broke = True
                         break

--- a/netbox_branching/merge_strategies/squash.py
+++ b/netbox_branching/merge_strategies/squash.py
@@ -422,16 +422,21 @@ class SquashMergeStrategy(MergeStrategy):
                         )
 
     @staticmethod
-    def _iter_create_references(create, creates):
+    def _iter_create_references(create, creates, ct_cache):
         """
         Yield ``(field_name, target_key, breakable)`` for every concrete ForeignKey and
         GenericForeignKey in ``create.postchange_data`` that points at another object in
-        ``creates`` (self-references excluded).
+        ``creates`` (self-references excluded). Fields are visited in model definition
+        order, so the yielded sequence is deterministic.
 
         ``breakable`` is True only for nullable concrete ForeignKeys — the edges a cycle
         can be deferred at by NULLing the field and restoring it in a follow-up UPDATE.
         GenericForeignKey edges are reported (so cycles through them are detected) but are
         never breakable, mirroring how NetBox persists these relationships at the DB level.
+
+        ``ct_cache`` memoises ContentType natural-key lookups (keyed by model class for
+        concrete FKs and by content-type id for GFKs) so repeated graph rebuilds don't
+        re-hit Django's ContentType cache once per FK field.
         """
         data = create.postchange_data
         if not data:
@@ -444,8 +449,11 @@ class SquashMergeStrategy(MergeStrategy):
             fk_value = data.get(field.name)
             if not fk_value:
                 continue
-            related_ct = ContentType.objects.get_for_model(field.related_model)
-            app_label, model = related_ct.natural_key()
+            natural_key = ct_cache.get(field.related_model)
+            if natural_key is None:
+                natural_key = ContentType.objects.get_for_model(field.related_model).natural_key()
+                ct_cache[field.related_model] = natural_key
+            app_label, model = natural_key
             target_key = (f"{app_label}.{model}", fk_value)
             if target_key in creates and target_key != create.key:
                 yield field.name, target_key, field.null
@@ -459,11 +467,14 @@ class SquashMergeStrategy(MergeStrategy):
             fk_value = data.get(field.fk_field)
             if not (ct_value and fk_value):
                 continue
-            try:
-                ct = ContentType.objects.get_for_id(ct_value)
-            except ContentType.DoesNotExist:
-                continue
-            app_label, model = ct.natural_key()
+            natural_key = ct_cache.get(ct_value)
+            if natural_key is None:
+                try:
+                    natural_key = ContentType.objects.get_for_id(ct_value).natural_key()
+                except ContentType.DoesNotExist:
+                    continue
+                ct_cache[ct_value] = natural_key
+            app_label, model = natural_key
             target_key = (f"{app_label}.{model}", fk_value)
             if target_key in creates and target_key != create.key:
                 yield field.name, target_key, False
@@ -471,9 +482,11 @@ class SquashMergeStrategy(MergeStrategy):
     @staticmethod
     def _find_cycle(adjacency):
         """
-        Return a single cycle in the directed graph ``adjacency`` (mapping key -> set of
-        target keys) as a list of keys ``[n0, n1, ..., nk]`` where each consecutive pair
-        and the closing pair ``(nk, n0)`` is an edge. Returns None if the graph is acyclic.
+        Return a single cycle in the directed graph ``adjacency`` (mapping key -> ordered
+        iterable of target keys) as a list of keys ``[n0, n1, ..., nk]`` where each
+        consecutive pair and the closing pair ``(nk, n0)`` is an edge. Returns None if the
+        graph is acyclic. Neighbours are visited in iteration order, so for a given graph
+        the cycle returned is deterministic.
 
         Uses iterative (stack-based) DFS with white/gray/black colouring so deep graphs
         do not hit Python's recursion limit.
@@ -521,6 +534,13 @@ class SquashMergeStrategy(MergeStrategy):
         and emitting a synthetic follow-up UPDATE that restores the original value once the
         referenced object exists. Mirrors how NetBox itself persists self-referential
         topologies such as ``primary_ip4`` / ``Circuit.termination_a``.
+
+        The UPDATE's ``postchange_data`` is a full snapshot, but it is applied as a diff
+        (``ObjectChange.apply`` -> ``get_merge_data`` -> ``diff_for_merge`` of pre vs post),
+        so only ``field_name`` is actually written. This is what makes deferring multiple
+        FKs on the same object safe: a later deferral NULLs another field in this snapshot,
+        but because that field is unchanged between this UPDATE's pre/post it is excluded
+        from the diff and therefore never clobbers the value restored by its own UPDATE.
         """
         original_postchange = dict(create.postchange_data)
         create.postchange_data[field_name] = None
@@ -558,19 +578,25 @@ class SquashMergeStrategy(MergeStrategy):
 
         broken_fields = set()  # (create_key, field_name) already deferred — don't redo
         ignored_edges = set()  # unbreakable edges excluded from detection to make progress
+        ct_cache = {}  # memoised ContentType natural keys; content types don't change mid-operation
         # Safety bound: every iteration either defers an FK or ignores an edge, both finite.
         max_iterations = 2 * sum(len(c.postchange_data or {}) for c in creates.values()) + len(creates) + 1
 
         for _ in range(max_iterations):
             # (Re)build the adjacency graph from the current postchange data, so deferred
-            # edges drop out automatically once their field has been NULLed.
-            adjacency = {key: set() for key in creates}
+            # edges drop out automatically once their field has been NULLed. Targets are
+            # stored as ordered lists (deduped) so cycle detection is deterministic.
+            adjacency = {key: [] for key in creates}
             edge_fields = {}  # (src_key, dst_key) -> list of (field_name, breakable)
             for key, create in creates.items():
-                for field_name, target_key, breakable in SquashMergeStrategy._iter_create_references(create, creates):
+                seen_targets = set()
+                refs = SquashMergeStrategy._iter_create_references(create, creates, ct_cache)
+                for field_name, target_key, breakable in refs:
                     if (key, target_key) in ignored_edges:
                         continue
-                    adjacency[key].add(target_key)
+                    if target_key not in seen_targets:
+                        seen_targets.add(target_key)
+                        adjacency[key].append(target_key)
                     edge_fields.setdefault((key, target_key), []).append((field_name, breakable))
 
             cycle = SquashMergeStrategy._find_cycle(adjacency)
@@ -599,7 +625,9 @@ class SquashMergeStrategy(MergeStrategy):
                 # No deferrable edge in this cycle: leave the data untouched so the
                 # topological sort reports it, but ignore one of its edges so detection
                 # can move on to find any other (breakable) cycles.
-                src, dst = cycle[0], cycle[1 % len(cycle)]
+                # A cycle always spans at least two distinct nodes (self-references are
+                # excluded when building the graph), so cycle[1] is always a valid edge.
+                src, dst = cycle[0], cycle[1]
                 ignored_edges.add((src, dst))
                 logger.warning(
                     f"  Unbreakable dependency cycle (length {len(cycle)}) involving "

--- a/netbox_branching/merge_strategies/squash.py
+++ b/netbox_branching/merge_strategies/squash.py
@@ -550,10 +550,12 @@ class SquashMergeStrategy(MergeStrategy):
         original_postchange = dict(create.postchange_data)
         create.postchange_data[field_name] = None
 
-        # 3-tuple keys distinguish synthetic UPDATEs from real (2-tuple) changes; assert the
-        # contract so a future 3-tuple key elsewhere can't silently overwrite a real change.
+        # 3-tuple keys distinguish synthetic UPDATEs from real (2-tuple) changes; enforce the
+        # contract with an unconditional raise (not assert, which is stripped under -O) so a
+        # future 3-tuple key elsewhere can't silently overwrite a real change.
         update_key = (create.key[0], create.key[1], f'update_{field_name}')
-        assert update_key not in collapsed_changes, f"Unexpected key collision: {update_key}"
+        if update_key in collapsed_changes:
+            raise RuntimeError(f"Unexpected key collision while deferring FK: {update_key}")
 
         update_collapsed = CollapsedChange(update_key, create.model_class)
         update_collapsed.change_count = 1  # Synthetic update from split
@@ -639,9 +641,20 @@ class SquashMergeStrategy(MergeStrategy):
                     break
 
             if not broke:
-                # No deferrable edge in this cycle: leave the data untouched so the
-                # topological sort reports it, but ignore one of its edges so detection
-                # can move on to find any other (breakable) cycles.
+                # No deferrable edge in this cycle. Reaching here means the merge is already
+                # doomed: this cycle survives untouched into the real dependency graph (we
+                # modified no data), so _dependency_order_by_references will fail on it
+                # regardless of anything else we do. We don't bail immediately only so the
+                # logs surface every distinct problem cycle, not just the first.
+                #
+                # To keep finding those other cycles we drop one edge of this one from the
+                # *detection* graph so _find_cycle stops returning it. We remove a single edge
+                # (the minimum to make progress), not the whole cycle's edge set: removing
+                # more would hide additional cycles that share those edges, which is the
+                # opposite of what we want here. A shared edge could in theory belong to an
+                # otherwise-breakable cycle we then miss, but that cannot rescue the merge —
+                # this unbreakable cycle already blocks the topological sort.
+                #
                 # A cycle always spans at least two distinct nodes (self-references are
                 # excluded when building the graph), so cycle[1] is always a valid edge.
                 src, dst = cycle[0], cycle[1]

--- a/netbox_branching/merge_strategies/squash.py
+++ b/netbox_branching/merge_strategies/squash.py
@@ -422,106 +422,192 @@ class SquashMergeStrategy(MergeStrategy):
                         )
 
     @staticmethod
-    def _has_fk_to(collapsed, target_model_class, target_obj_id):
+    def _iter_create_references(create, creates):
         """
-        Check if a CollapsedChange has a foreign key reference to a specific object.
-        Returns True if any FK or GenericFK field in postchange_data points to the target object.
+        Yield ``(field_name, target_key, breakable)`` for every concrete ForeignKey and
+        GenericForeignKey in ``create.postchange_data`` that points at another object in
+        ``creates`` (self-references excluded).
+
+        ``breakable`` is True only for nullable concrete ForeignKeys — the edges a cycle
+        can be deferred at by NULLing the field and restoring it in a follow-up UPDATE.
+        GenericForeignKey edges are reported (so cycles through them are detected) but are
+        never breakable, mirroring how NetBox persists these relationships at the DB level.
         """
-        if not collapsed.postchange_data:
-            return False
+        data = create.postchange_data
+        if not data:
+            return
 
-        for field in collapsed.model_class._meta.get_fields():
-            if isinstance(field, models.ForeignKey):
-                fk_value = collapsed.postchange_data.get(field.name)
-                if fk_value:
-                    # Check if this FK points to target model
-                    related_model = field.related_model
-                    if related_model == target_model_class and fk_value == target_obj_id:
-                        return True
+        # Concrete ForeignKey fields
+        for field in create.model_class._meta.get_fields():
+            if not isinstance(field, models.ForeignKey):
+                continue
+            fk_value = data.get(field.name)
+            if not fk_value:
+                continue
+            related_ct = ContentType.objects.get_for_model(field.related_model)
+            app_label, model = related_ct.natural_key()
+            target_key = (f"{app_label}.{model}", fk_value)
+            if target_key in creates and target_key != create.key:
+                yield field.name, target_key, field.null
 
-        for field in collapsed.model_class._meta.private_fields:
-            if isinstance(field, GenericForeignKey):
-                # ObjectChange data may store the CT FK as either 'field_name' or 'field_name_id'
-                ct_value = (collapsed.postchange_data.get(field.ct_field)
-                            or collapsed.postchange_data.get(field.ct_field + '_id'))
-                fk_value = collapsed.postchange_data.get(field.fk_field)
-                if ct_value and fk_value == target_obj_id:
-                    try:
-                        ct = ContentType.objects.get_for_id(ct_value)
-                        if ct.model_class() == target_model_class:
-                            return True
-                    except ContentType.DoesNotExist:
-                        pass
-
-        return False
+        # GenericForeignKey fields
+        for field in create.model_class._meta.private_fields:
+            if not isinstance(field, GenericForeignKey):
+                continue
+            # ObjectChange data may store the CT FK as either 'field_name' or 'field_name_id'
+            ct_value = data.get(field.ct_field) or data.get(field.ct_field + '_id')
+            fk_value = data.get(field.fk_field)
+            if not (ct_value and fk_value):
+                continue
+            try:
+                ct = ContentType.objects.get_for_id(ct_value)
+            except ContentType.DoesNotExist:
+                continue
+            app_label, model = ct.natural_key()
+            target_key = (f"{app_label}.{model}", fk_value)
+            if target_key in creates and target_key != create.key:
+                yield field.name, target_key, False
 
     @staticmethod
-    def _split_bidirectional_cycles(collapsed_changes, logger):
+    def _find_cycle(adjacency):
         """
-        Special case: Preemptively detect and split CREATE operations involved in
-        bidirectional FK cycles.
+        Return a single cycle in the directed graph ``adjacency`` (mapping key -> set of
+        target keys) as a list of keys ``[n0, n1, ..., nk]`` where each consecutive pair
+        and the closing pair ``(nk, n0)`` is an edge. Returns None if the graph is acyclic.
 
-        For each CREATE A with a nullable FK to CREATE B, check if CREATE B has any FK back to A.
-        If so, split CREATE A by setting the nullable FK to NULL and creating a separate UPDATE.
-
-        This handles the common case of bidirectional FK relationships (e.g., Circuit ↔ CircuitTermination)
-        without needing complex cycle detection.
+        Uses iterative (stack-based) DFS with white/gray/black colouring so deep graphs
+        do not hit Python's recursion limit.
         """
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color = {node: WHITE for node in adjacency}
+        parent = {}
 
-        creates = {key: c for key, c in collapsed_changes.items() if c.final_action == ActionType.CREATE}
-        splits_made = 0
-
-        for key_a, create_a in list(creates.items()):
-            if not create_a.postchange_data:
+        for start in adjacency:
+            if color[start] != WHITE:
                 continue
+            color[start] = GRAY
+            stack = [(start, iter(adjacency[start]))]
+            while stack:
+                node, neighbors = stack[-1]
+                advanced = False
+                for target in neighbors:
+                    if target not in color:
+                        continue  # target is not itself a tracked CREATE node
+                    if color[target] == WHITE:
+                        color[target] = GRAY
+                        parent[target] = node
+                        stack.append((target, iter(adjacency[target])))
+                        advanced = True
+                        break
+                    if color[target] == GRAY:
+                        # Back edge node -> target closes a cycle; walk parents back up.
+                        cycle = [node]
+                        cursor = node
+                        while cursor != target:
+                            cursor = parent[cursor]
+                            cycle.append(cursor)
+                        cycle.reverse()
+                        return cycle
+                if not advanced:
+                    color[node] = BLACK
+                    stack.pop()
 
-            # Find nullable FK fields in this CREATE
-            for field in create_a.model_class._meta.get_fields():
-                if not (isinstance(field, models.ForeignKey) and field.null):
-                    continue
+        return None
 
-                fk_value = create_a.postchange_data.get(field.name)
-                if not fk_value:
-                    continue
+    @staticmethod
+    def _defer_fk(collapsed_changes, create, field_name, logger):
+        """
+        Break a cycle at ``create``'s nullable FK ``field_name`` by NULLing it on the CREATE
+        and emitting a synthetic follow-up UPDATE that restores the original value once the
+        referenced object exists. Mirrors how NetBox itself persists self-referential
+        topologies such as ``primary_ip4`` / ``Circuit.termination_a``.
+        """
+        original_postchange = dict(create.postchange_data)
+        create.postchange_data[field_name] = None
 
-                # Get the target's key
-                related_model = field.related_model
-                target_ct = ContentType.objects.get_for_model(related_model)
-                app_label, model = target_ct.natural_key()
-                model_label = f"{app_label}.{model}"
-                key_b = (model_label, fk_value)
+        update_key = (create.key[0], create.key[1], f'update_{field_name}')
+        update_collapsed = CollapsedChange(update_key, create.model_class)
+        update_collapsed.change_count = 1  # Synthetic update from split
+        update_collapsed.final_action = ActionType.UPDATE
+        update_collapsed.prechange_data = dict(create.postchange_data)
+        update_collapsed.postchange_data = original_postchange
+        update_collapsed.last_change = create.last_change
 
-                # Is target also being created?
-                if key_b not in creates:
-                    continue
+        collapsed_changes[update_key] = update_collapsed
 
-                create_b = creates[key_b]
+    @staticmethod
+    def _break_dependency_cycles(collapsed_changes, logger):
+        """
+        Preemptively detect and break dependency cycles of any length among CREATE
+        operations.
 
-                # Does target have FK back to us? (bidirectional cycle)
-                if SquashMergeStrategy._has_fk_to(create_b, create_a.model_class, key_a[1]):
-                    logger.info(
-                        f"  Detected bidirectional cycle: {create_a.model_class.__name__}:{key_a[1]} ↔ "
-                        f"{create_b.model_class.__name__}:{key_b[1]} (via {field.name})"
-                    )
+        A cycle exists when a set of newly-created objects reference each other in a loop
+        via concrete ForeignKeys and/or GenericForeignKeys. Each cycle is broken at an
+        eligible edge — one backed by a nullable concrete ForeignKey — by deferring it:
+        the field is set NULL on the CREATE and a follow-up UPDATE restores it once the
+        referenced object exists (see ``_defer_fk``).
 
-                    # Split create_a: set nullable FK to NULL, create UPDATE to set it later
-                    original_postchange = dict(create_a.postchange_data)
-                    create_a.postchange_data[field.name] = None
+        The two-node case (e.g. Circuit ↔ CircuitTermination) is just the length-2
+        specialisation of this routine. The three-node primary-IP loop
+        (Device → IPAddress → Interface → Device) is broken at ``Device.primary_ip4``.
 
-                    # Create UPDATE operation
-                    update_key = (key_a[0], key_a[1], f'update_{field.name}')
-                    update_collapsed = CollapsedChange(update_key, create_a.model_class)
-                    update_collapsed.change_count = 1  # Synthetic update from split
-                    update_collapsed.final_action = ActionType.UPDATE
-                    update_collapsed.prechange_data = dict(create_a.postchange_data)
-                    update_collapsed.postchange_data = original_postchange
-                    update_collapsed.last_change = create_a.last_change
+        Cycles containing no deferrable (nullable concrete FK) edge are left in place for
+        the topological sort to report, as before.
+        """
+        creates = {key: c for key, c in collapsed_changes.items() if c.final_action == ActionType.CREATE}
 
-                    # Add UPDATE to collapsed_changes
-                    collapsed_changes[update_key] = update_collapsed
-                    splits_made += 1
+        broken_fields = set()  # (create_key, field_name) already deferred — don't redo
+        ignored_edges = set()  # unbreakable edges excluded from detection to make progress
+        # Safety bound: every iteration either defers an FK or ignores an edge, both finite.
+        max_iterations = 2 * sum(len(c.postchange_data or {}) for c in creates.values()) + len(creates) + 1
 
+        for _ in range(max_iterations):
+            # (Re)build the adjacency graph from the current postchange data, so deferred
+            # edges drop out automatically once their field has been NULLed.
+            adjacency = {key: set() for key in creates}
+            edge_fields = {}  # (src_key, dst_key) -> list of (field_name, breakable)
+            for key, create in creates.items():
+                for field_name, target_key, breakable in SquashMergeStrategy._iter_create_references(create, creates):
+                    if (key, target_key) in ignored_edges:
+                        continue
+                    adjacency[key].add(target_key)
+                    edge_fields.setdefault((key, target_key), []).append((field_name, breakable))
+
+            cycle = SquashMergeStrategy._find_cycle(adjacency)
+            if cycle is None:
+                return
+
+            # Find a deferrable edge along the cycle and break it there.
+            broke = False
+            for i, src in enumerate(cycle):
+                dst = cycle[(i + 1) % len(cycle)]
+                for field_name, breakable in edge_fields.get((src, dst), ()):
+                    if breakable and (src, field_name) not in broken_fields:
+                        logger.info(
+                            f"  Breaking dependency cycle at {creates[src].model_class.__name__}:{src[1]} "
+                            f".{field_name} -> {creates[dst].model_class.__name__}:{dst[1]} "
+                            f"(cycle length {len(cycle)})"
+                        )
+                        SquashMergeStrategy._defer_fk(collapsed_changes, creates[src], field_name, logger)
+                        broken_fields.add((src, field_name))
+                        broke = True
+                        break
+                if broke:
                     break
+
+            if not broke:
+                # No deferrable edge in this cycle: leave the data untouched so the
+                # topological sort reports it, but ignore one of its edges so detection
+                # can move on to find any other (breakable) cycles.
+                src, dst = cycle[0], cycle[1 % len(cycle)]
+                ignored_edges.add((src, dst))
+                logger.warning(
+                    f"  Unbreakable dependency cycle (length {len(cycle)}) involving "
+                    f"{creates[src].model_class.__name__}:{src[1]}; no nullable FK to defer. "
+                    f"Leaving for topological sort to report."
+                )
+
+        logger.warning("  Cycle breaking exceeded its iteration bound; remaining cycles left for topological sort.")
 
     @staticmethod
     def _log_cycle_details(remaining, collapsed_changes, logger, max_to_show=5):
@@ -674,9 +760,9 @@ class SquashMergeStrategy(MergeStrategy):
         if not to_process:
             return []
 
-        # Preemptively detect and split bidirectional FK cycles
-        # This may add new UPDATE operations to to_process
-        SquashMergeStrategy._split_bidirectional_cycles(to_process, logger)
+        # Preemptively detect and break FK dependency cycles of any length.
+        # This may add new UPDATE operations to to_process.
+        SquashMergeStrategy._break_dependency_cycles(to_process, logger)
 
         # Group by action and sort each group by time - need this to build the
         # dependency graph correctly

--- a/netbox_branching/tests/test_squash_merge.py
+++ b/netbox_branching/tests/test_squash_merge.py
@@ -4,7 +4,7 @@ Tests for Branch merge functionality with ObjectChange collapsing using squash m
 import uuid
 
 from circuits.models import Circuit, CircuitTermination, CircuitType, Provider
-from dcim.models import Device, Interface, Location, Region, Site
+from dcim.models import Device, Interface, Location, Region, Site, VirtualChassis
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TransactionTestCase
@@ -304,6 +304,215 @@ class SquashMergeTestCase(BaseMergeTests, TransactionTestCase):
         # Verify revert deleted both objects
         self.assertFalse(Circuit.objects.filter(id=circuit_id).exists())
         self.assertFalse(CircuitTermination.objects.filter(id=termination_id).exists())
+
+    def test_merge_device_primary_ip_on_own_interface(self):
+        """
+        Regression test for GitHub issue #608.
+
+        A Device whose primary_ip4 lives on one of its own newly-created interfaces forms a
+        three-node CREATE cycle that the old two-node-only splitter could not break:
+
+            Device    --primary_ip4 (nullable FK)--> IPAddress
+            IPAddress --assigned_object (GFK)-------> Interface
+            Interface --device (FK)-----------------> Device
+
+        The generalised cycle breaker defers Device.primary_ip4, so the squash merge
+        succeeds (Device created with primary_ip4 NULL, then Interface, then IP, then a
+        follow-up UPDATE backfills primary_ip4).
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # Site lives in main; the device topology is created entirely in the branch.
+        with event_tracking(request):
+            site = Site.objects.create(name='Test Site', slug='test-site')
+
+        branch = self._create_and_provision_branch()
+
+        request2 = RequestFactory().get(reverse('home'))
+        request2.id = uuid.uuid4()
+        request2.user = self.user
+
+        with activate_branch(branch), event_tracking(request2):
+            device = Device.objects.create(
+                name='Test Device',
+                site=site,
+                device_type=self.device_type,
+                role=self.device_role,
+            )
+            iface = Interface.objects.create(device=device, name='eth0', type='virtual')
+            ip = IPAddress.objects.create(address='10.0.0.1/24')
+
+            ip.snapshot()
+            ip.assigned_object = iface
+            ip.save()
+
+            device.snapshot()
+            device.primary_ip4 = ip
+            device.save()
+
+            device_id, iface_id, ip_id = device.id, iface.id, ip.id
+
+        # Squash merge — previously raised "Cycle detected in dependency graph".
+        branch.merge(user=self.user, commit=True)
+
+        self.assertTrue(Device.objects.filter(id=device_id).exists())
+        self.assertTrue(Interface.objects.filter(id=iface_id).exists())
+        self.assertTrue(IPAddress.objects.filter(id=ip_id).exists())
+        self.assertEqual(Device.objects.get(id=device_id).primary_ip4_id, ip_id)
+        self.assertEqual(IPAddress.objects.get(id=ip_id).assigned_object_id, iface_id)
+
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)
+
+        # Revert cleanly removes the whole topology.
+        branch.revert(user=self.user, commit=True)
+        self.assertFalse(Device.objects.filter(id=device_id).exists())
+        self.assertFalse(Interface.objects.filter(id=iface_id).exists())
+        self.assertFalse(IPAddress.objects.filter(id=ip_id).exists())
+
+    def test_merge_device_dual_primary_ip4_and_ip6(self):
+        """
+        Variant of issue #608 where a Device has both primary_ip4 and primary_ip6 set to
+        new IPs on its own interface. Two distinct nullable-FK edges (primary_ip4 and
+        primary_ip6) must each be deferred to break the two interlocking cycles.
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with event_tracking(request):
+            site = Site.objects.create(name='Test Site', slug='test-site')
+
+        branch = self._create_and_provision_branch()
+
+        request2 = RequestFactory().get(reverse('home'))
+        request2.id = uuid.uuid4()
+        request2.user = self.user
+
+        with activate_branch(branch), event_tracking(request2):
+            device = Device.objects.create(
+                name='Test Device',
+                site=site,
+                device_type=self.device_type,
+                role=self.device_role,
+            )
+            iface = Interface.objects.create(device=device, name='eth0', type='virtual')
+
+            ip4 = IPAddress.objects.create(address='10.0.0.1/24')
+            ip4.snapshot()
+            ip4.assigned_object = iface
+            ip4.save()
+
+            ip6 = IPAddress.objects.create(address='2001:db8::1/64')
+            ip6.snapshot()
+            ip6.assigned_object = iface
+            ip6.save()
+
+            device.snapshot()
+            device.primary_ip4 = ip4
+            device.primary_ip6 = ip6
+            device.save()
+
+            device_id, iface_id = device.id, iface.id
+            ip4_id, ip6_id = ip4.id, ip6.id
+
+        branch.merge(user=self.user, commit=True)
+
+        merged_device = Device.objects.get(id=device_id)
+        self.assertEqual(merged_device.primary_ip4_id, ip4_id)
+        self.assertEqual(merged_device.primary_ip6_id, ip6_id)
+        self.assertEqual(IPAddress.objects.get(id=ip4_id).assigned_object_id, iface_id)
+        self.assertEqual(IPAddress.objects.get(id=ip6_id).assigned_object_id, iface_id)
+
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)
+
+        branch.revert(user=self.user, commit=True)
+        self.assertFalse(Device.objects.filter(id=device_id).exists())
+        self.assertFalse(IPAddress.objects.filter(id__in=[ip4_id, ip6_id]).exists())
+
+    def test_merge_multinode_cycle_via_virtual_chassis(self):
+        """
+        A longer, multi-node cycle spanning a virtual chassis. The VC master's primary IP
+        lives on an interface of a *different* member device, producing a five-node cycle
+        plus an interlocking two-node cycle:
+
+            Device1   --primary_ip4 (nullable FK)----> IPAddress
+            IPAddress --assigned_object (GFK)--------> Interface
+            Interface --device (FK)------------------> Device2
+            Device2   --virtual_chassis (nullable FK)-> VirtualChassis
+            VirtualChassis --master (nullable FK)----> Device1
+            Device1   --virtual_chassis (nullable FK)-> VirtualChassis  (2-node with master)
+
+        The generalised breaker must defer multiple nullable FK edges to untangle all of
+        the interlocking cycles before the topological sort runs.
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with event_tracking(request):
+            site = Site.objects.create(name='Test Site', slug='test-site')
+
+        branch = self._create_and_provision_branch()
+
+        request2 = RequestFactory().get(reverse('home'))
+        request2.id = uuid.uuid4()
+        request2.user = self.user
+
+        with activate_branch(branch), event_tracking(request2):
+            vc = VirtualChassis.objects.create(name='VC1')
+
+            device1 = Device.objects.create(
+                name='Device 1', site=site, device_type=self.device_type, role=self.device_role,
+            )
+            device2 = Device.objects.create(
+                name='Device 2', site=site, device_type=self.device_type, role=self.device_role,
+            )
+
+            # The primary IP of device1 lives on an interface of device2.
+            iface = Interface.objects.create(device=device2, name='eth0', type='virtual')
+            ip = IPAddress.objects.create(address='10.0.0.1/24')
+            ip.snapshot()
+            ip.assigned_object = iface
+            ip.save()
+
+            device1.snapshot()
+            device1.primary_ip4 = ip
+            device1.virtual_chassis = vc
+            device1.vc_position = 1
+            device1.save()
+
+            device2.snapshot()
+            device2.virtual_chassis = vc
+            device2.vc_position = 2
+            device2.save()
+
+            vc.snapshot()
+            vc.master = device1
+            vc.save()
+
+            vc_id = vc.id
+            device1_id, device2_id = device1.id, device2.id
+            iface_id, ip_id = iface.id, ip.id
+
+        branch.merge(user=self.user, commit=True)
+
+        self.assertEqual(Device.objects.get(id=device1_id).primary_ip4_id, ip_id)
+        self.assertEqual(Device.objects.get(id=device1_id).virtual_chassis_id, vc_id)
+        self.assertEqual(Device.objects.get(id=device2_id).virtual_chassis_id, vc_id)
+        self.assertEqual(VirtualChassis.objects.get(id=vc_id).master_id, device1_id)
+        self.assertEqual(IPAddress.objects.get(id=ip_id).assigned_object_id, iface_id)
+
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)
+
+        branch.revert(user=self.user, commit=True)
+        self.assertFalse(Device.objects.filter(id__in=[device1_id, device2_id]).exists())
+        self.assertFalse(VirtualChassis.objects.filter(id=vc_id).exists())
+        self.assertFalse(IPAddress.objects.filter(id=ip_id).exists())
 
     def test_merge_squash_multiple_field_changes(self):
         """

--- a/netbox_branching/tests/test_squash_merge.py
+++ b/netbox_branching/tests/test_squash_merge.py
@@ -431,6 +431,7 @@ class SquashMergeTestCase(BaseMergeTests, TransactionTestCase):
 
         branch.revert(user=self.user, commit=True)
         self.assertFalse(Device.objects.filter(id=device_id).exists())
+        self.assertFalse(Interface.objects.filter(id=iface_id).exists())
         self.assertFalse(IPAddress.objects.filter(id__in=[ip4_id, ip6_id]).exists())
 
     def test_merge_multinode_cycle_via_virtual_chassis(self):


### PR DESCRIPTION
### Fixes: #608 

Squash merge aborted with "Cycle detected in dependency graph" whenever new objects formed an FK cycle longer than two nodes — most commonly a Device/VM whose primary_ip4 points at an IP on one of its own new interfaces (Device → IPAddress → Interface → Device). The old _split_bidirectional_cycles only detected and broke two-node (A↔B) loops, so this three-node loop was never broken and the topological sort failed.

Replaced _split_bidirectional_cycles (and unused helper _has_fk_to) with a generalized _break_dependency_cycles that handles cycles of any length: it builds a graph over collapsed CREATEs from concrete FKs and GenericForeignKeys, finds cycles via iterative DFS, and breaks each at a nullable concrete FK edge by deferring it (NULL on the CREATE + synthetic follow-up UPDATE) - the same mechanism the old code used, now generalized. 

The two-node case is now the length-2 specialization. Cycles with no deferrable edge are still left for the topological sort to report.
