### PR TITLE
#610 - Fix MPTT Component Models for Iterative Merge

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -85,9 +85,16 @@ class ObjectChange(ObjectChange_):
             # other rows (e.g. due to order_insertion_by) — those side-effects aren't in
             # the changelog, so reusing the source's tree fields would leave the
             # destination tree inconsistent and break later parent updates. (#531)
+            #
+            # force_insert is required because the deserialized instance carries a preset
+            # PK. Without it, MPTT's _is_saved() can report the node as already existing
+            # (e.g. ModuleBay's save() repopulates tree_id, so tree_id is no longer None)
+            # and route it through the "move existing node" path, which forces an UPDATE
+            # with update_fields that matches zero rows and raises NotUpdated. Applying a
+            # CREATE change is always an INSERT, so force_insert is correct here. (#610)
             if isinstance(instance.object, MPTTModel):
                 clear_mptt_fields(instance.object)
-                instance.object.save(using=using)
+                instance.object.save(using=using, force_insert=True)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
             else:
@@ -159,7 +166,17 @@ class ObjectChange(ObjectChange_):
                         setattr(instance, field.name, ct_field.get_object_for_this_type(pk=fk_field))
 
             instance.full_clean()
-            instance.save(using=using)
+
+            # Restoring a deleted object is an INSERT, so it hits the same MPTT hazard as
+            # applying a create: the preset PK (and, for models like ModuleBay whose save()
+            # repopulates tree_id, a non-null tree_id) makes MPTT treat the row as existing
+            # and force a zero-row UPDATE. Clear the tree fields and force the insert so MPTT
+            # recomputes them against the local tree. (#531, #610)
+            if isinstance(instance, MPTTModel):
+                clear_mptt_fields(instance)
+                instance.save(using=using, force_insert=True)
+            else:
+                instance.save(using=using)
 
     undo.alters_data = True
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -171,10 +171,16 @@ class ObjectChange(ObjectChange_):
             # applying a create: the preset PK (and, for models like ModuleBay whose save()
             # repopulates tree_id, a non-null tree_id) makes MPTT treat the row as existing
             # and force a zero-row UPDATE. Clear the tree fields and force the insert so MPTT
-            # recomputes them against the local tree. (#531, #610)
+            # recomputes them against the local tree. force_insert requires saving the raw
+            # instance, which bypasses DeserializedObject's M2M handling, so — exactly as the
+            # MPTT create path above does — reassign the M2M data explicitly. This is scoped
+            # to MPTT models to match the create fix; the non-MPTT branch is left unchanged.
+            # (#531, #610)
             if isinstance(instance, MPTTModel):
                 clear_mptt_fields(instance)
                 instance.save(using=using, force_insert=True)
+                for accessor_name, object_list in (deserialized.m2m_data or {}).items():
+                    getattr(instance, accessor_name).set(object_list)
             else:
                 instance.save(using=using)
 

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -967,14 +967,19 @@ class BaseMergeTests:
     def test_merge_revert_restores_deleted_mptt_object(self):
         """
         Deleting an MPTT component (ModuleBay) in a branch and then reverting the merge
-        must restore it. The restore path deserializes the object with its original PK,
-        so it hits the same MPTT insert-vs-update hazard as a create. (#610)
+        must restore it, including its M2M relationships (e.g. tags). The restore path
+        deserializes the object with its original PK, so it hits the same MPTT
+        insert-vs-update hazard as a create and bypasses DeserializedObject's M2M
+        handling. (#610)
         """
+        tag1 = Tag.objects.create(name='Tag 1', slug='tag-1')
+        tag2 = Tag.objects.create(name='Tag 2', slug='tag-2')
+
         request = RequestFactory().get(reverse('home'))
         request.id = uuid.uuid4()
         request.user = self.user
 
-        # In main: a device with two module bays.
+        # In main: a device with two module bays; tag one of them.
         with event_tracking(request):
             ModuleBayTemplate.objects.create(device_type=self.device_type, name='Module Bay 1')
             ModuleBayTemplate.objects.create(device_type=self.device_type, name='Module Bay 2')
@@ -982,15 +987,16 @@ class BaseMergeTests:
             device = Device.objects.create(
                 name='Device 1', device_type=self.device_type, role=self.device_role, site=site
             )
-        device_id = device.id
-        deleted_bay = ModuleBay.objects.filter(device_id=device_id).order_by('pk').first()
+            device_id = device.id
+            deleted_bay = ModuleBay.objects.filter(device_id=device_id).order_by('pk').first()
+            deleted_bay.tags.add(tag1, tag2)
         deleted_bay_id = deleted_bay.id
         deleted_bay_name = deleted_bay.name
 
         # Create branch
         branch = self._create_and_provision_branch()
 
-        # In branch: delete one module bay
+        # In branch: delete the tagged module bay
         with activate_branch(branch), event_tracking(request):
             ModuleBay.objects.get(id=deleted_bay_id).delete()
 
@@ -998,11 +1004,12 @@ class BaseMergeTests:
         branch.merge(user=self.user, commit=True)
         self.assertFalse(ModuleBay.objects.filter(id=deleted_bay_id).exists())
 
-        # Revert branch: the module bay is restored in main
+        # Revert branch: the module bay and its tags are restored in main
         branch.revert(user=self.user, commit=True)
         restored = ModuleBay.objects.filter(id=deleted_bay_id)
         self.assertEqual(restored.count(), 1)
         self.assertEqual(restored.first().name, deleted_bay_name)
+        self.assertEqual(set(restored.first().tags.all()), {tag1, tag2})
 
     def test_merge_many_to_many_tags(self):
         """

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -12,6 +12,8 @@ from dcim.models import (
     DeviceType,
     Interface,
     Manufacturer,
+    ModuleBay,
+    ModuleBayTemplate,
     Region,
     Site,
     VirtualChassis,
@@ -915,6 +917,92 @@ class BaseMergeTests:
         # Verify new nodes are deleted
         self.assertFalse(Region.objects.filter(id=grandchild_a2_1_id).exists())
         self.assertFalse(Region.objects.filter(id=great_grandchild_id).exists())
+
+    def test_merge_module_bays(self):
+        """
+        Create a device whose device type defines module bays. NetBox instantiates a
+        ModuleBay (an MPTT model) per template. Because the deserialized instances carry
+        a preset PK and ModuleBay.save() repopulates tree_id, merging previously drove
+        MPTT into its "move existing node" path and raised NotUpdated. Merge must insert
+        the module bays into main, and revert must remove them again. (#610)
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # Add module bays to the device type and a site to hold the device (in main).
+        with event_tracking(request):
+            ModuleBayTemplate.objects.create(device_type=self.device_type, name='Module Bay 1')
+            ModuleBayTemplate.objects.create(device_type=self.device_type, name='Module Bay 2')
+            site = Site.objects.create(name='Site 1', slug='site-1')
+
+        # Create branch
+        branch = self._create_and_provision_branch()
+
+        # In branch: create a device from the device type (instantiates two ModuleBays)
+        with activate_branch(branch), event_tracking(request):
+            device = Device.objects.create(
+                name='Device 1', device_type=self.device_type, role=self.device_role, site=site
+            )
+            device_id = device.id
+            self.assertEqual(ModuleBay.objects.filter(device=device).count(), 2)
+
+        # Merge branch
+        branch.merge(user=self.user, commit=True)
+
+        # Device and its module bays now exist in main
+        self.assertTrue(Device.objects.filter(id=device_id).exists())
+        module_bays = ModuleBay.objects.filter(device_id=device_id)
+        self.assertEqual(module_bays.count(), 2)
+        # Each root module bay should have received a distinct tree_id
+        self.assertEqual(len(set(module_bays.values_list('tree_id', flat=True))), 2)
+
+        # Revert branch
+        branch.revert(user=self.user, commit=True)
+
+        # Device and its module bays are removed again
+        self.assertFalse(Device.objects.filter(id=device_id).exists())
+        self.assertEqual(ModuleBay.objects.filter(device_id=device_id).count(), 0)
+
+    def test_merge_revert_restores_deleted_mptt_object(self):
+        """
+        Deleting an MPTT component (ModuleBay) in a branch and then reverting the merge
+        must restore it. The restore path deserializes the object with its original PK,
+        so it hits the same MPTT insert-vs-update hazard as a create. (#610)
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In main: a device with two module bays.
+        with event_tracking(request):
+            ModuleBayTemplate.objects.create(device_type=self.device_type, name='Module Bay 1')
+            ModuleBayTemplate.objects.create(device_type=self.device_type, name='Module Bay 2')
+            site = Site.objects.create(name='Site 1', slug='site-1')
+            device = Device.objects.create(
+                name='Device 1', device_type=self.device_type, role=self.device_role, site=site
+            )
+        device_id = device.id
+        deleted_bay = ModuleBay.objects.filter(device_id=device_id).order_by('pk').first()
+        deleted_bay_id = deleted_bay.id
+        deleted_bay_name = deleted_bay.name
+
+        # Create branch
+        branch = self._create_and_provision_branch()
+
+        # In branch: delete one module bay
+        with activate_branch(branch), event_tracking(request):
+            ModuleBay.objects.get(id=deleted_bay_id).delete()
+
+        # Merge branch: the module bay is deleted in main
+        branch.merge(user=self.user, commit=True)
+        self.assertFalse(ModuleBay.objects.filter(id=deleted_bay_id).exists())
+
+        # Revert branch: the module bay is restored in main
+        branch.revert(user=self.user, commit=True)
+        restored = ModuleBay.objects.filter(id=deleted_bay_id)
+        self.assertEqual(restored.count(), 1)
+        self.assertEqual(restored.first().name, deleted_bay_name)
 
     def test_merge_many_to_many_tags(self):
         """


### PR DESCRIPTION
### Fixes: #610

Merging a branch that creates an MPTT component model (e.g. a Device with module bays) errored with ModuleBay.NotUpdated / TransactionManagementError.

The cause was applying a CREATE deserializes the object with its PK preset. ModuleBay.save() repopulates tree_id, so MPTT's _is_saved() treats the row as existing and forces a zero-row UPDATE instead of an INSERT, raising NotUpdated. Reverting a deleted MPTT object hit the same issue.

Fix: pass force_insert=True on the MPTT save in both the create and restore paths — applying a create (or restoring a deletion) is always an INSERT.

Added tests covering the full merge→revert lifecycle for both iterative and squash strategies.

**Note:** This has direct dependency on MPTT which will need to be changed for 4.7 where we replace it with LTree, but there are already dependencies in branching for MPTT that will need to be updated so will leave that for another issue.