### PR TITLE
#107 - Auto Archive merged branches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,27 @@ A list of import paths to functions which validate whether a branch is permitted
 
 ---
 
+## `auto_archive_days`
+
+Default: `30`
+
+The number of days after which a merged branch is automatically archived. A daily background job archives any branch whose merge occurred more than this many days ago, providing a housekeeping mechanism to clean up old branches which are no longer needed and help combat database bloat.
+
+Set to `None` to disable automatic archival entirely.
+
+```python
+PLUGINS_CONFIG = {
+    'netbox_branching': {
+        'auto_archive_days': 60,
+    }
+}
+```
+
+!!! note
+    Archiving a branch drops its PostgreSQL schema but retains the `Branch` record and its merged change history. Any [archive validators](#archive_validators) configured are honoured; a branch which a validator blocks from being archived is skipped and left in the merged state.
+
+---
+
 ## `exempt_models`
 
 Default: `[]` (empty list)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,19 +25,22 @@ A list of import paths to functions which validate whether a branch is permitted
 
 ## `auto_archive_days`
 
-Default: `30`
+Default: `None` (disabled)
 
-The number of days after which a merged branch is automatically archived. A daily background job archives any branch whose merge occurred more than this many days ago, providing a housekeeping mechanism to clean up old branches which are no longer needed and help combat database bloat.
+The number of days after which a merged branch is automatically archived. When set to an integer, a daily background job archives any branch whose merge occurred more than this many days ago, providing a housekeeping mechanism to clean up old branches which are no longer needed and help combat database bloat.
 
-Set to `None` to disable automatic archival entirely.
+Automatic archival is disabled by default. Set this to an integer number of days to enable it.
 
 ```python
 PLUGINS_CONFIG = {
     'netbox_branching': {
-        'auto_archive_days': 60,
+        'auto_archive_days': 30,
     }
 }
 ```
+
+!!! warning
+    Once a branch has been archived its PostgreSQL schema is dropped and it can no longer be reverted. Enable this setting only if you are comfortable with old merged branches becoming non-revertible after the configured number of days.
 
 !!! note
     Archiving a branch drops its PostgreSQL schema but retains the `Branch` record and its merged change history. Any [archive validators](#archive_validators) configured are honoured; a branch which a validator blocks from being archived is skipped and left in the merged state.

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -90,6 +90,19 @@ class AppConfig(PluginConfig):
                     "netbox_branching: 'provision_workers' must be greater than or equal to 1."
                 )
 
+        # Validate auto_archive_days up front so a misconfigured value surfaces at startup rather
+        # than as an opaque timedelta error the first time the daily archival job runs.
+        auto_archive_days = get_plugin_config('netbox_branching', 'auto_archive_days')
+        if auto_archive_days is not None:
+            if type(auto_archive_days) is not int:
+                raise ImproperlyConfigured(
+                    "netbox_branching: 'auto_archive_days' must be an integer or None."
+                )
+            if auto_archive_days < 1:
+                raise ImproperlyConfigured(
+                    "netbox_branching: 'auto_archive_days' must be greater than or equal to 1."
+                )
+
         # Register cleanup handler for branch connections (#358)
         # This ensures branch connections are closed when they exceed CONN_MAX_AGE,
         # preventing connection leaks. Django's built-in close_old_connections()

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -53,13 +53,17 @@ class AppConfig(PluginConfig):
 
         # Number of days before staleness at which to display a stale warning
         'stale_warning_threshold': 7,
+
+        # Automatically archive branches merged more than this many days ago (via a daily job).
+        # Set to None to disable automatic archival.
+        'auto_archive_days': 30,
     }
 
     def ready(self):
         super().ready()
         from django.core.signals import request_finished, request_started
 
-        from . import constants, events, search, signal_receivers, webhook_callbacks  # noqa: F401
+        from . import constants, events, jobs, search, signal_receivers, webhook_callbacks  # noqa: F401
         from .models import Branch
         from .utilities import DynamicSchemaDict, close_old_branch_connections
 

--- a/netbox_branching/__init__.py
+++ b/netbox_branching/__init__.py
@@ -55,8 +55,8 @@ class AppConfig(PluginConfig):
         'stale_warning_threshold': 7,
 
         # Automatically archive branches merged more than this many days ago (via a daily job).
-        # Set to None to disable automatic archival.
-        'auto_archive_days': 30,
+        # Set to an integer number of days to enable automatic archival.
+        'auto_archive_days': None,
     }
 
     def ready(self):
@@ -100,7 +100,7 @@ class AppConfig(PluginConfig):
                 )
             if auto_archive_days < 1:
                 raise ImproperlyConfigured(
-                    "netbox_branching: 'auto_archive_days' must be greater than or equal to 1."
+                    "netbox_branching: 'auto_archive_days' must be greater than or equal to 1 (if enabled)."
                 )
 
         # Register cleanup handler for branch connections (#358)

--- a/netbox_branching/jobs.py
+++ b/netbox_branching/jobs.py
@@ -269,30 +269,22 @@ class AutoArchiveBranchJob(JobRunner):
 
         auto_archive_days = get_plugin_config('netbox_branching', 'auto_archive_days')
         if auto_archive_days is None:
-            self.logger.info("Automatic branch archival is disabled (auto_archive_days is None); skipping.")
+            # Automatic archival is disabled; nothing to do.
             return
 
         cutoff = timezone.now() - timedelta(days=auto_archive_days)
-        # Fetch only PKs to avoid loading a large backlog of merged branches into memory. Not
-        # .iterator(): its server-side cursor would hold one transaction open across the whole
-        # loop, defeating the per-branch transaction isolation each archive() relies on.
-        branch_pks = list(
+        branches = list(
             Branch.objects.filter(
                 status=BranchStatusChoices.MERGED,
                 merged_time__lt=cutoff,
-            ).values_list('pk', flat=True)
+            )
         )
         self.logger.info(
-            f"Found {len(branch_pks)} merged branch(es) merged before {cutoff:%Y-%m-%d %H:%M:%S} "
+            f"Found {len(branches)} merged branch(es) merged before {cutoff:%Y-%m-%d %H:%M:%S} "
             f"eligible for automatic archival."
         )
 
-        for pk in branch_pks:
-            # Re-fetch each branch for its current state; it may have been archived or deleted
-            # since the initial query was taken.
-            branch = Branch.objects.filter(pk=pk).first()
-            if branch is None or branch.status != BranchStatusChoices.MERGED:
-                continue
+        for branch in branches:
             # Respect any configured archive validators; skip (rather than fail) branches which
             # are not permitted to be archived so a single blocked branch can't stall the batch.
             if not branch.can_archive:

--- a/netbox_branching/jobs.py
+++ b/netbox_branching/jobs.py
@@ -273,11 +273,9 @@ class AutoArchiveBranchJob(JobRunner):
             return
 
         cutoff = timezone.now() - timedelta(days=auto_archive_days)
-        # Fetch only the PKs rather than whole Branch rows so a large backlog of merged branches
-        # isn't loaded into memory all at once. We deliberately don't use .iterator() here: each
-        # archive() commits in its own transaction, whereas a server-side cursor would hold a
-        # single transaction open across the entire loop, defeating that per-branch isolation and
-        # holding locks for the job's full duration.
+        # Fetch only PKs to avoid loading a large backlog of merged branches into memory. Not
+        # .iterator(): its server-side cursor would hold one transaction open across the whole
+        # loop, defeating the per-branch transaction isolation each archive() relies on.
         branch_pks = list(
             Branch.objects.filter(
                 status=BranchStatusChoices.MERGED,

--- a/netbox_branching/jobs.py
+++ b/netbox_branching/jobs.py
@@ -1,25 +1,28 @@
 import logging
 from collections import defaultdict
 from contextlib import contextmanager
+from datetime import timedelta
 
-from core.choices import ObjectChangeActionChoices
+from core.choices import JobIntervalChoices, ObjectChangeActionChoices
 from core.signals import handle_changed_object, handle_deleted_object
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.db.models import Case, IntegerField, Max, When
 from django.db.models.signals import m2m_changed, post_save, pre_delete
-from netbox.jobs import JobRunner
+from django.utils import timezone
+from netbox.jobs import JobRunner, system_job
 from netbox.plugins import get_plugin_config
 from netbox.signals import post_clean
 from utilities.exceptions import AbortTransaction
 
-from .choices import BranchMergeStrategyChoices
+from .choices import BranchMergeStrategyChoices, BranchStatusChoices
 from .error_report import build_error_report
 from .signal_receivers import validate_branching_operations
 from .utilities import ListHandler
 
 __all__ = (
+    'AutoArchiveBranchJob',
     'MergeBranchJob',
     'MigrateBranchJob',
     'ProvisionBranchJob',
@@ -248,3 +251,47 @@ class MigrateBranchJob(BranchJobRunner):
                 branch.migrate(user=self.job.user)
             except AbortTransaction:
                 logger.info("Dry run completed; rolling back changes")
+
+
+@system_job(interval=JobIntervalChoices.INTERVAL_DAILY)
+class AutoArchiveBranchJob(JobRunner):
+    """
+    Automatically archive branches which were merged more than `auto_archive_days` days ago. This
+    daily housekeeping job cleans up old merged branches which are no longer needed, helping to
+    combat database bloat. Archival is disabled entirely when `auto_archive_days` is None.
+    """
+    class Meta:
+        name = 'Auto-archive branches'
+
+    def run(self, *args, **kwargs):
+        # Import here to avoid a circular import at module load time (models imports jobs).
+        from .models import Branch
+
+        auto_archive_days = get_plugin_config('netbox_branching', 'auto_archive_days')
+        if auto_archive_days is None:
+            self.logger.info("Automatic branch archival is disabled (auto_archive_days is None); skipping.")
+            return
+
+        cutoff = timezone.now() - timedelta(days=auto_archive_days)
+        branches = Branch.objects.filter(
+            status=BranchStatusChoices.MERGED,
+            merged_time__lt=cutoff,
+        )
+        self.logger.info(
+            f"Found {len(branches)} merged branch(es) merged before {cutoff:%Y-%m-%d %H:%M:%S} "
+            f"eligible for automatic archival."
+        )
+
+        for branch in branches:
+            # Respect any configured archive validators; skip (rather than fail) branches which
+            # are not permitted to be archived so a single blocked branch can't stall the batch.
+            if not branch.can_archive:
+                self.logger.warning(f"Skipping branch {branch}: archival is not permitted.")
+                continue
+            try:
+                self.logger.info(
+                    f"Archiving branch {branch} (merged {branch.merged_time:%Y-%m-%d %H:%M:%S})."
+                )
+                branch.archive(user=self.job.user)
+            except Exception as e:  # noqa: BLE001 — isolate failures so one branch can't abort the batch
+                self.logger.error(f"Failed to archive branch {branch}: {e}")

--- a/netbox_branching/jobs.py
+++ b/netbox_branching/jobs.py
@@ -273,16 +273,28 @@ class AutoArchiveBranchJob(JobRunner):
             return
 
         cutoff = timezone.now() - timedelta(days=auto_archive_days)
-        branches = Branch.objects.filter(
-            status=BranchStatusChoices.MERGED,
-            merged_time__lt=cutoff,
+        # Fetch only the PKs rather than whole Branch rows so a large backlog of merged branches
+        # isn't loaded into memory all at once. We deliberately don't use .iterator() here: each
+        # archive() commits in its own transaction, whereas a server-side cursor would hold a
+        # single transaction open across the entire loop, defeating that per-branch isolation and
+        # holding locks for the job's full duration.
+        branch_pks = list(
+            Branch.objects.filter(
+                status=BranchStatusChoices.MERGED,
+                merged_time__lt=cutoff,
+            ).values_list('pk', flat=True)
         )
         self.logger.info(
-            f"Found {len(branches)} merged branch(es) merged before {cutoff:%Y-%m-%d %H:%M:%S} "
+            f"Found {len(branch_pks)} merged branch(es) merged before {cutoff:%Y-%m-%d %H:%M:%S} "
             f"eligible for automatic archival."
         )
 
-        for branch in branches:
+        for pk in branch_pks:
+            # Re-fetch each branch for its current state; it may have been archived or deleted
+            # since the initial query was taken.
+            branch = Branch.objects.filter(pk=pk).first()
+            if branch is None or branch.status != BranchStatusChoices.MERGED:
+                continue
             # Respect any configured archive validators; skip (rather than fail) branches which
             # are not permitted to be archived so a single blocked branch can't stall the batch.
             if not branch.can_archive:

--- a/netbox_branching/tests/test_jobs.py
+++ b/netbox_branching/tests/test_jobs.py
@@ -14,6 +14,7 @@ critically:
     a FAILED state with a structured report attached to job.data)
 """
 import weakref
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest import mock
 
@@ -22,11 +23,14 @@ from core.signals import handle_changed_object, handle_deleted_object
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.db.models.signals import m2m_changed, post_save, pre_delete
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.utils import timezone
 from netbox.signals import post_clean
 from utilities.exceptions import AbortTransaction
 
+from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.jobs import (
+    AutoArchiveBranchJob,
     MergeBranchJob,
     MigrateBranchJob,
     RevertBranchJob,
@@ -35,6 +39,7 @@ from netbox_branching.jobs import (
 )
 from netbox_branching.models import Branch
 from netbox_branching.signal_receivers import validate_branching_operations
+from netbox_branching.utilities import BranchActionIndicator
 
 
 def _receivers_for(signal):
@@ -219,3 +224,75 @@ class JobRunWrapperTestCase(TestCase):
         self.assertEqual(summary['creates_total'], 0)
         self.assertEqual(summary['updates_total'], 0)
         self.assertEqual(summary['deletes_total'], 0)
+
+
+class AutoArchiveBranchJobTestCase(TestCase):
+    """
+    AutoArchiveBranchJob is the daily system job that archives merged branches once they
+    exceed the `auto_archive_days` threshold (issue #107). These tests exercise the selection
+    logic and the disable/skip paths. The branches are never provisioned, so archive()'s
+    DROP SCHEMA IF EXISTS is a harmless no-op — only the status transition matters here.
+    """
+
+    def _make_job(self):
+        # AutoArchiveBranchJob.run() uses self.logger (which dispatches to job.log) and
+        # self.job.user; it never touches job.object. Provide just enough of a stub.
+        return SimpleNamespace(object=None, user=None, data={}, log=lambda record: None)
+
+    def _run(self):
+        AutoArchiveBranchJob(self._make_job()).run()
+
+    def _make_merged_branch(self, name, days_ago):
+        branch = Branch(name=name, status=BranchStatusChoices.MERGED)
+        branch.save(provision=False)
+        Branch.objects.filter(pk=branch.pk).update(
+            merged_time=timezone.now() - timedelta(days=days_ago)
+        )
+        branch.refresh_from_db()
+        return branch
+
+    @override_settings(PLUGINS_CONFIG={'netbox_branching': {'auto_archive_days': 30}})
+    def test_archives_branches_merged_before_cutoff(self):
+        branch = self._make_merged_branch('Stale', days_ago=31)
+        self._run()
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.ARCHIVED)
+
+    @override_settings(PLUGINS_CONFIG={'netbox_branching': {'auto_archive_days': 30}})
+    def test_leaves_recently_merged_branches(self):
+        branch = self._make_merged_branch('Recent', days_ago=1)
+        self._run()
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)
+
+    @override_settings(PLUGINS_CONFIG={'netbox_branching': {'auto_archive_days': 30}})
+    def test_ignores_non_merged_branches(self):
+        # A ready (never-merged) branch has no merged_time and must be left untouched.
+        branch = Branch(name='Ready', status=BranchStatusChoices.READY)
+        branch.save(provision=False)
+        self._run()
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.READY)
+
+    @override_settings(PLUGINS_CONFIG={'netbox_branching': {'auto_archive_days': None}})
+    def test_disabled_when_auto_archive_days_is_none(self):
+        branch = self._make_merged_branch('Stale', days_ago=365)
+        self._run()
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)
+
+    @override_settings(PLUGINS_CONFIG={'netbox_branching': {'auto_archive_days': 30}})
+    def test_skips_branches_blocked_by_validator(self):
+        branch = self._make_merged_branch('Blocked', days_ago=31)
+
+        def deny(branch):
+            return BranchActionIndicator(False, 'archival blocked')
+
+        Branch.register_preaction_check(deny, 'archive')
+        try:
+            self._run()
+        finally:
+            Branch._preaction_validators['archive'].discard(deny)
+
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)


### PR DESCRIPTION
### Fixes: #107 

Adds a housekeeping mechanism to automatically archive old merged branches, helping combat database bloat from schemas that are no longer needed.

- New auto_archive_days config parameter (default: 30). Merged branches whose merge occurred more than this many days ago are archived automatically. Set to None to disable.
- New AutoArchiveBranchJob that finds MERGED branches past the cutoff and archives them. Configured archive validators are honored (blocked branches are skipped, not force-archived), and per-branch failures are isolated so one bad branch can't abort the batch.
- The plugin's ready() now imports jobs so the system job registers at worker startup.

## Notes

- Archival records a BranchEvent with a null user (system-initiated) and drops the branch's PostgreSQL schema while retaining the Branch record and merged change history - consistent with manual archival.
- Documented under docs/configuration.md.