### PR TITLE
Fixes #624: Ensure conflicts are recorded in ChangeDiff records during object updates

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -251,7 +251,10 @@ class ChangeDiff(models.Model):
 
     def save(self, *args, **kwargs):
         self._update_conflicts()
-        if self.object:
+        # Resolving the object (a GenericForeignKey) and rendering it as a string can require several
+        # queries, so skip it entirely when object_repr is not among the fields being saved.
+        update_fields = kwargs.get('update_fields')
+        if (update_fields is None or 'object_repr' in update_fields) and self.object:
             self.object_repr = str(self.object)
 
         super().save(*args, **kwargs)
@@ -281,11 +284,11 @@ class ChangeDiff(models.Model):
         if self.action == ObjectChangeActionChoices.ACTION_UPDATE:
             if current is None:
                 # Object was deleted in main; all branch modifications are in conflict
-                conflicts = [k for k, v in original.items() if v != modified[k]]
+                conflicts = [k for k, v in original.items() if v != modified.get(k)]
             else:
                 conflicts = [
                     k for k, v in original.items()
-                    if v != modified[k] and v != current.get(k) and modified[k] != current.get(k)
+                    if v != modified.get(k) and v != current.get(k) and modified.get(k) != current.get(k)
                 ]
         elif self.action == ObjectChangeActionChoices.ACTION_DELETE:
             if current is None:

--- a/netbox_branching/signal_receivers.py
+++ b/netbox_branching/signal_receivers.py
@@ -6,10 +6,9 @@ from core.models import ObjectChange, ObjectType
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import DEFAULT_DB_ALIAS, DatabaseError, connections, transaction
 from django.db.models.signals import post_migrate, post_save, pre_delete
 from django.dispatch import receiver
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from extras.events import process_event_rules
 from extras.models import EventRule
@@ -134,26 +133,26 @@ def record_change_diff(instance, **kwargs):
         if instance.action == ObjectChangeActionChoices.ACTION_CREATE:
             return
 
-        logger.debug(f"Updating change diff for global change to {instance.changed_object}")
-        ChangeDiff.objects.filter(
+        if logger.isEnabledFor(logging.DEBUG):
+            # changed_object is a GenericForeignKey, so it is resolved eagerly as an argument even
+            # though logger.debug() would defer the formatting.
+            logger.debug("Updating change diff for global change to %s", instance.changed_object)
+        current_data = instance.postchange_data_clean or None
+        for diff in ChangeDiff.objects.filter(
             object_type=content_type,
             object_id=object_id,
             branch__status=BranchStatusChoices.READY
-        ).update(
-            last_updated=timezone.now(),
-            current=instance.postchange_data_clean or None
-        )
-
-        # When main deletes an object, recompute conflicts for any branch edits on that object,
-        # as the branch-UPDATE + main-DELETE combination is not caught by the bulk update above.
-        if instance.action == ObjectChangeActionChoices.ACTION_DELETE:
-            for diff in ChangeDiff.objects.filter(
-                object_type=content_type,
-                object_id=object_id,
-                branch__status=BranchStatusChoices.READY,
-                action=ObjectChangeActionChoices.ACTION_UPDATE,
-            ):
-                diff.save()
+        ).select_related('object_type'):
+            diff.current = current_data
+            # object_repr is excluded from update_fields because save() recomputes it from the
+            # GenericForeignKey, which resolves against main here (no active branch). The stored
+            # value must keep reflecting the branch's view of the object.
+            try:
+                with transaction.atomic():
+                    diff.save(update_fields=('current', 'conflicts', 'last_updated'))
+            except DatabaseError:
+                # The ChangeDiff was deleted (e.g. along with its Branch) after being retrieved above.
+                logger.debug("ChangeDiff %s no longer exists; skipping update", diff.pk)
 
     # If this is a branch-aware change, create or update ChangeDiff for this object.
     else:

--- a/netbox_branching/tests/test_changediff.py
+++ b/netbox_branching/tests/test_changediff.py
@@ -1,10 +1,21 @@
+import uuid
 from datetime import timedelta
 
 from core.choices import ObjectChangeActionChoices
+from dcim.models import Site
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.test import SimpleTestCase, TestCase
+from django.db import connections, transaction
+from django.db.models.signals import post_save
+from django.test import RequestFactory, SimpleTestCase, TestCase, TransactionTestCase
+from django.urls import reverse
+from netbox.context_managers import event_tracking
 
 from netbox_branching.models import Branch, ChangeDiff
+from netbox_branching.tests.utils import provision_branch
+from netbox_branching.utilities import activate_branch
+
+User = get_user_model()
 
 DATA_A = {'name': 'foo', 'description': ''}
 DATA_B = {'name': 'foo', 'description': 'changed'}
@@ -160,3 +171,254 @@ class LastUpdatedTestCase(TestCase):
         diff.save()
         diff.refresh_from_db()
         self.assertGreater(diff.last_updated, original)
+
+
+class MainSideConflictTestCase(TransactionTestCase):
+    """
+    Conflicts must be recorded when the change in main arrives *after* the branch's
+    change. Previously the global-change path in record_change_diff() refreshed
+    ChangeDiff.current with a queryset update(), which bypasses save() and therefore
+    _update_conflicts(), leaving the stored conflicts stale (usually NULL). Every
+    consumer of the field was affected, including the API's 409 conflict gate and the
+    merge form's acknowledgement check.
+
+    The ordering matters: when main changes first, the branch's own change re-saves the
+    ChangeDiff and recomputes conflicts as a side effect, which masked the bug.
+    """
+
+    serialized_rollback = True
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='testuser')
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+        self.request = request
+
+    def tearDown(self):
+        for branch in Branch.objects.all():
+            if hasattr(connections._connections, branch.connection_name):
+                connections[branch.connection_name].close()
+
+    def _get_diff(self, branch, site_id):
+        """Fetch the ChangeDiff straight from the database, without re-saving it."""
+        return ChangeDiff.objects.get(
+            branch=branch,
+            object_type=ContentType.objects.get_for_model(Site),
+            object_id=site_id,
+        )
+
+    def test_conflict_recorded_for_main_change_after_branch_change(self):
+        with event_tracking(self.request):
+            site = Site.objects.create(name='Site 1', slug='site-1', description='original')
+        site_id = site.pk
+
+        branch = provision_branch(user=self.user, name='Branch 1')
+
+        # Branch changes the description first
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(pk=site_id)
+            branch_site.snapshot()
+            branch_site.description = 'branch-desc'
+            branch_site.save()
+
+        self.assertIsNone(self._get_diff(branch, site_id).conflicts)
+
+        # Main then changes the same field to a different value
+        with event_tracking(self.request):
+            main_site = Site.objects.get(pk=site_id)
+            main_site.snapshot()
+            main_site.description = 'main-desc'
+            main_site.save()
+
+        diff = self._get_diff(branch, site_id)
+        self.assertEqual(diff.current['description'], 'main-desc')
+        self.assertEqual(diff.conflicts, ['description'])
+
+    def test_no_conflict_for_main_change_to_unrelated_field(self):
+        with event_tracking(self.request):
+            site = Site.objects.create(
+                name='Site 2', slug='site-2', description='original', status='active'
+            )
+        site_id = site.pk
+
+        branch = provision_branch(user=self.user, name='Branch 2')
+
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(pk=site_id)
+            branch_site.snapshot()
+            branch_site.description = 'branch-desc'
+            branch_site.save()
+
+        # Main changes a field the branch never touched
+        with event_tracking(self.request):
+            main_site = Site.objects.get(pk=site_id)
+            main_site.snapshot()
+            main_site.status = 'staging'
+            main_site.save()
+
+        diff = self._get_diff(branch, site_id)
+        self.assertEqual(diff.current['status'], 'staging')
+        self.assertIsNone(diff.conflicts)
+
+    def test_conflict_cleared_when_main_matches_branch_value(self):
+        """
+        A conflict recorded from an earlier change in main must also be cleared once a
+        later change in main converges on the branch's value.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(name='Site 3', slug='site-3', description='original')
+        site_id = site.pk
+
+        branch = provision_branch(user=self.user, name='Branch 3')
+
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(pk=site_id)
+            branch_site.snapshot()
+            branch_site.description = 'agreed-desc'
+            branch_site.save()
+
+        with event_tracking(self.request):
+            main_site = Site.objects.get(pk=site_id)
+            main_site.snapshot()
+            main_site.description = 'main-desc'
+            main_site.save()
+
+        self.assertEqual(self._get_diff(branch, site_id).conflicts, ['description'])
+
+        # Main converges on the branch's value; the conflict is no longer real
+        with event_tracking(self.request):
+            main_site = Site.objects.get(pk=site_id)
+            main_site.snapshot()
+            main_site.description = 'agreed-desc'
+            main_site.save()
+
+        self.assertIsNone(self._get_diff(branch, site_id).conflicts)
+
+    def test_object_repr_reflects_branch_after_main_change(self):
+        """
+        Saving the ChangeDiff to recompute conflicts must not overwrite object_repr with
+        main's representation: it records the branch's view of the object.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(name='Original Name', slug='site-4')
+        site_id = site.pk
+
+        branch = provision_branch(user=self.user, name='Branch 4')
+
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(pk=site_id)
+            branch_site.snapshot()
+            branch_site.name = 'Branch Name'
+            branch_site.save()
+
+        self.assertEqual(self._get_diff(branch, site_id).object_repr, 'Branch Name')
+
+        with event_tracking(self.request):
+            main_site = Site.objects.get(pk=site_id)
+            main_site.snapshot()
+            main_site.description = 'changed in main'
+            main_site.save()
+
+        self.assertEqual(self._get_diff(branch, site_id).object_repr, 'Branch Name')
+
+    def test_conflict_recorded_when_main_deletes_object(self):
+        """
+        The branch-UPDATE + main-DELETE combination previously needed its own
+        recompute loop; it must keep working now that every diff is saved individually.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(name='Site 5', slug='site-5', description='original')
+        site_id = site.pk
+
+        branch = provision_branch(user=self.user, name='Branch 5')
+
+        with activate_branch(branch), event_tracking(self.request):
+            branch_site = Site.objects.get(pk=site_id)
+            branch_site.snapshot()
+            branch_site.description = 'branch-desc'
+            branch_site.save()
+
+        with event_tracking(self.request):
+            Site.objects.get(pk=site_id).delete()
+
+        diff = self._get_diff(branch, site_id)
+        self.assertIsNone(diff.current)
+        self.assertEqual(diff.conflicts, ['description'])
+
+    def test_deleted_diff_does_not_abort_main_write(self):
+        """
+        A ChangeDiff removed (e.g. by branch deprovisioning) between the receiver's
+        SELECT and its save() must not abort the enclosing write to main.
+        """
+        with event_tracking(self.request):
+            site = Site.objects.create(name='Site 6', slug='site-6', description='original')
+        site_id = site.pk
+
+        branch_1 = provision_branch(user=self.user, name='Branch 6a')
+        branch_2 = provision_branch(user=self.user, name='Branch 6b')
+        for branch in (branch_1, branch_2):
+            with activate_branch(branch), event_tracking(self.request):
+                branch_site = Site.objects.get(pk=site_id)
+                branch_site.snapshot()
+                branch_site.description = f'{branch.name} desc'
+                branch_site.save()
+        self.assertEqual(ChangeDiff.objects.filter(object_id=site_id).count(), 2)
+
+        def delete_sibling_diffs(sender, instance, **kwargs):
+            # Stand in for the branch being deprovisioned mid-loop: the receiver has already
+            # selected both diffs, so the second save() will match zero rows.
+            ChangeDiff.objects.filter(object_id=site_id).exclude(pk=instance.pk).delete()
+
+        post_save.connect(delete_sibling_diffs, sender=ChangeDiff)
+        try:
+            # The atomic() block stands in for the view's transaction, which is what makes an
+            # escaping exception poison the connection rather than merely propagate.
+            with transaction.atomic():
+                with event_tracking(self.request):
+                    main_site = Site.objects.get(pk=site_id)
+                    main_site.snapshot()
+                    main_site.description = 'changed in main'
+                    main_site.save()
+                # The transaction must still be usable after the swallowed error.
+                self.assertTrue(Site.objects.filter(pk=site_id).exists())
+        finally:
+            post_save.disconnect(delete_sibling_diffs, sender=ChangeDiff)
+
+        self.assertEqual(Site.objects.get(pk=site_id).description, 'changed in main')
+
+
+class DivergentKeySetTestCase(TestCase):
+    """
+    original is captured from the branch's first change while modified is refreshed on every
+    subsequent one, so a NetBox upgrade that adds or renames a field with no registered migrator
+    can leave their key sets divergent. A key missing from modified must not raise KeyError: the
+    global-change path now reaches this code, where the exception would propagate out of the
+    post_save receiver and roll back an unrelated write to main.
+    """
+
+    def _diff(self, **kwargs):
+        return ChangeDiff(
+            object_type=ContentType.objects.get_for_model(Site),
+            object_id=1,
+            action=ObjectChangeActionChoices.ACTION_UPDATE,
+            **kwargs,
+        )
+
+    def test_key_missing_from_modified_with_object_deleted_in_main(self):
+        diff = self._diff(
+            original={'name': 'foo', 'retired': 'x'},
+            modified={'name': 'foo'},
+            current=None,
+        )
+        diff._update_conflicts()
+        self.assertEqual(diff.conflicts, ['retired'])
+
+    def test_key_missing_from_modified_with_object_present_in_main(self):
+        diff = self._diff(
+            original={'name': 'foo', 'retired': 'x'},
+            modified={'name': 'foo'},
+            current={'name': 'foo', 'retired': 'y'},
+        )
+        diff._update_conflicts()
+        self.assertEqual(diff.conflicts, ['retired'])


### PR DESCRIPTION
### Fixes: #624

Records `ChangeDiff` conflicts when the change in main arrives *after* the branch's change, so a divergence like the one in #624 is surfaced as a conflict the user must acknowledge instead of a sync/merge job that errors out with no prior warning.

## The bug

`record_change_diff()` handles a change made in main by refreshing `ChangeDiff.current` for every branch that has touched the same object. It did so with a queryset `update()`:

```python
ChangeDiff.objects.filter(...).update(
    last_updated=timezone.now(),
    current=instance.postchange_data_clean or None
)
```

A queryset `update()` bypasses `Model.save()`, and `_update_conflicts()` only runs from `ChangeDiff.save()`. So `current` was refreshed while `conflicts` was left at whatever the branch's own change had computed earlier — normally `NULL`. A main-side change could therefore introduce a genuine field-level conflict that was never recorded.

Everything that reads the field was affected: the API's 409 conflict gate (`BranchViewSet._check_conflicts`), the merge form's "all conflicts must be acknowledged" check, the conflict indicators in the diff table, and the `has_conflicts` filter.

The ordering is what makes this easy to miss. When main changes *first*, the branch's subsequent change re-saves the `ChangeDiff` and recomputes conflicts as a side effect — and every existing conflict test in the suite happens to use that order. Only main-after-branch hits the broken path, which is exactly the sequence in #624 (the branch unracks the device, then main changes `face`).

The main-side DELETE case already needed its own recompute loop to work around the bulk update; that workaround is now unnecessary.

## The fix

Save each `ChangeDiff` individually so `_update_conflicts()` re-runs:

```python
for diff in ChangeDiff.objects.filter(...).select_related('object_type'):
    diff.current = current_data
    try:
        with transaction.atomic():
            diff.save(update_fields=('current', 'conflicts', 'last_updated'))
    except DatabaseError:
        logger.debug("ChangeDiff %s no longer exists; skipping update", diff.pk)
```

`update_fields` deliberately omits `object_repr`. `save()` recomputes it from the GenericForeignKey, which resolves against main here (there is no active branch in this path), and the stored value must keep reflecting the branch's view of the object — otherwise renaming an object in a branch and then editing it in main would relabel the branch's diff row with main's name.

The DELETE-specific recompute loop is removed, as the unified loop covers it.

### `ChangeDiff.save()` now honours `update_fields`

```python
update_fields = kwargs.get('update_fields')
if (update_fields is None or 'object_repr' in update_fields) and self.object:
    self.object_repr = str(self.object)
```

`save()` previously resolved the GenericForeignKey and called `str()` on the result unconditionally, then discarded the value whenever `object_repr` was excluded from `update_fields` — as it is in the loop above. That is a wasted `SELECT` per diff, plus whatever the model's `__str__` costs (an unnamed `Device.__str__` walks `device_type.manufacturer`, so 2–3 queries).

It matters because this is a hot path during a merge: `IterativeMergeStrategy.merge()` writes a main-side `ObjectChange` per applied change inside `event_tracking()`, so the loop runs once per applied change for every *other* READY branch holding a diff on that object. The waste scales with changes × branches, inside the merge transaction. Full saves (`update_fields=None`) still recompute `object_repr`, so behaviour is unchanged.

### Zero-row saves

`save(update_fields=...)` raises when the row matches nothing, where the previous bulk `update()` was silent on zero matches. `ChangeDiff.branch` is `on_delete=CASCADE`, so a branch deleted or deprovisioned between this loop's `SELECT` and a given row's `save()` reaches that path. Two details govern how it has to be handled:

**The exception type depends on the Django version.** Django 6.0 raises `Model.NotUpdated`, but Django 5.2 — which NetBox 4.4.1 (`Django==5.2.6`) and 4.5.0 (`Django==5.2.9`) pin, against a declared `min_version` of 4.4.1 — raises a plain `DatabaseError`, and `ChangeDiff.NotUpdated` does not exist there at all. Naming it in the `except` clause would raise `AttributeError` on the two oldest supported NetBox versions, replacing the original error with a more confusing one. Django 6.0 deliberately makes the per-model exception a `DatabaseError` subclass for backward compatibility (`NotUpdated → ObjectNotUpdated → DatabaseError`), so a single `except DatabaseError` covers NetBox 4.4 through 4.6.

**Catching it is not sufficient on its own.** `Model.save_base()` wraps `_save_table()` in `transaction.mark_for_rollback_on_error()`, which sets `needs_rollback` on the connection whenever the save raises inside an atomic block — and this receiver runs inside the view's transaction. Swallowing the exception without a savepoint therefore leaves the connection poisoned and the unrelated write to main still fails, just as `TransactionManagementError` rather than the original error. The inner `transaction.atomic()` gives the failed save a savepoint to roll back to, so the enclosing transaction stays usable.

### Divergent key sets in `_update_conflicts()`

```python
conflicts = [k for k, v in original.items() if v != modified.get(k)]
```

`original` is captured from the branch's first change while `modified` is refreshed on every subsequent one, so their key sets can diverge across a NetBox upgrade that adds or renames a field with no registered migrator. The previous `modified[k]` raised `KeyError` on such a key. That line used to be reachable only from a branch-side save; now that a main-side change recomputes conflicts, the exception would propagate out of the `post_save` receiver and roll back an unrelated write to main.

`modified.get(k)` matches the `current.get(k)` already used alongside it. A key missing from `modified` compares as `None` and is reported as a conflict, which surfaces the divergence for the user to resolve rather than silently merging past it.

### Query cost

An object with no branch diffs now costs one `SELECT` returning zero rows instead of one `UPDATE` matching zero rows. Where diffs do exist, there is at most one per READY branch that has touched that object, and each is now a bare `UPDATE` with no GFK resolution behind it.

The debug log at the top of the same path is guarded with `logger.isEnabledFor(logging.DEBUG)`. `instance.changed_object` is a GenericForeignKey resolved eagerly as a call argument, so `logger.debug("... %s", instance.changed_object)` defers the *formatting* but not the `SELECT` — it would otherwise cost a query on every main-side change regardless of log level, on the same path where skipping `object_repr` saves one.

## Tests

New `MainSideConflictTestCase` in `tests/test_changediff.py`, going through the real signal path with a provisioned branch:

- a conflict is recorded when main changes the same field after the branch did;
- no false conflict when main changes a field the branch never touched;
- an existing conflict is *cleared* when a later change in main converges on the branch's value;
- `object_repr` still reflects the branch after a main-side change;
- the branch-UPDATE + main-DELETE combination still records a conflict (coverage for the removed loop);
- a `ChangeDiff` deleted between the loop's `SELECT` and its `save()` is skipped without aborting the enclosing write to main.

New `DivergentKeySetTestCase` covers `_update_conflicts()` when a key in `original` is absent from `modified`, both with and without the object still present in main.

Each of these fails with its corresponding fix reverted:

| Test | Failure without the fix |
|---|---|
| `test_conflict_recorded_for_main_change_after_branch_change` | `None != ['description']` |
| `test_conflict_cleared_when_main_matches_branch_value` | `None != ['description']` |
| `test_deleted_diff_does_not_abort_main_write` | `TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.` |
| `DivergentKeySetTestCase` (both) | `KeyError: 'retired'` |

The remainder are guards against regressing the surrounding behaviour.

## Verification

- `netbox_branching.tests.test_changediff` — 29 tests, OK, against a NetBox `main` checkout on Django 6.0.8.
- Every new regression test confirmed to fail with its fix reverted, as tabulated above.
- `ruff check` clean.

Two caveats on coverage:

- The Django 5.2 behaviour described under "Zero-row saves" is established from the Django sources (`Model.NotUpdated` was introduced by `ab148c02ce`, first released in 6.0; `git show 5.2:django/db/models/base.py` has no reference to it), not by execution — only Django 6.0.8 is installed locally. CI's NetBox matrix is what will exercise the 5.2 path.
- The wider comparison run (`test_iterative_merge`, `test_squash_merge`, `test_sync`, `test_api`, `test_views` — 231 tests, run twice against the same database, once with these changes and once with them stashed) was performed against the first version of this fix and has **not** been repeated since the changes above. It reported 1 failure / 1 error / 2 skipped identically in both runs; both are pre-existing against a NetBox `main` checkout:
  - `test_merge_after_sync_cascade_delete_of_branch_modified_object` raises `select_for_update cannot be used outside of a transaction` from inside NetBox's own `dcim.signals.handle_location_site_change`;
  - `test_list_objects_with_permission` trips a stale query-count baseline (`query_counts.json` expects 21; NetBox `main` now issues 19). None of the 19 observed queries touch this code path.

## Not addressed here

This makes the #624 divergence *visible and gated* rather than a job failure with no warning, but it does not make that sync succeed. The underlying cause of the `ValidationError` is separate: `update_object()` replays only the fields in a single `ObjectChange` diff and then calls `full_clean()` on the whole object, so a replay's validity depends on fields it never touched, and `Device.clean()` enforces a relationship between `rack`, `position`, and `face`.

Because conflict detection is per-field, it also cannot express that class of divergence. There are combinations with **no** field-level conflict at all that still fail — e.g. baseline `rack=rack01, position=null, face=front`, the branch sets `position=2`, main clears `face`: each change is valid alone, neither side touches the same field, and replaying main's `{'face': ''}` onto the branch raises `{'face': ['Must specify rack face when defining rack position.']}`.

Fixing that means handling the `ValidationError` during replay — recording it against the object's `ChangeDiff` as an unresolvable conflict naming all the mutually dependent fields, instead of aborting the job — and is left for a follow-up.
