### PR TITLE
#634 publish pre-release builds to PyPi from tag pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,24 @@
 name: Release
 
+# Releases are driven by pushing a v* tag, not by publishing a GitHub release, so that
+# pre-releases (v1.3.0-beta1 -> 1.3.0b1 on PyPI) follow the same automated path as a
+# final release. The GitHub release is created by this workflow after PyPI accepts the
+# upload; see the release job below.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - '.github/workflows/release.yaml'
+      - 'pyproject.toml'
+      - 'scripts/verify_*.py'
+      - 'netbox_branching/**'
+      - 'README.md'
+      - 'LICENSE.md'
+  workflow_dispatch:
 
+# Least-privilege default for every job; the publish and release jobs widen this themselves.
 permissions:
   contents: read
 
@@ -12,37 +27,212 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.x"
-    - name: Install pypa/build
-      run: |
-        python3 -m pip install build
-    - name: Build distribution package
-      run: |
-        python3 -m build
-    - name: Upload distribution package
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: python-package-distributions
-        path: dist/
-        if-no-files-found: error
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-  publish:
-    name: Publish to PyPI
-    needs:
-      - build
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine packaging
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
+      - name: Verify the release tag and version declarations
+        # Runs here, in the unprivileged build job, against the exact artifacts this run
+        # uploads, so neither publish job needs a checkout while holding id-token: write.
+        # A failure skips every downstream job. On pull requests and branch dispatches
+        # there is no tag, and only pyproject.toml, AppConfig.version and the wheel are
+        # cross-checked.
+        env:
+          TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+        run: |
+          if [[ -n "$TAG" ]]; then
+            [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+              echo "Ref '$TAG' is not a release tag of the form vX.Y.Z[-designation]"
+              exit 1
+            }
+            python scripts/verify_release_tag.py --tag "$TAG" dist/*.whl
+          else
+            python scripts/verify_release_tag.py dist/*.whl
+          fi
+
+      - name: Verify the wheel contents
+        run: python scripts/verify_wheel_contents.py dist/*.whl
+
+      - name: Upload distribution package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  verify-sdist:
+    name: Verify the sdist builds a wheel
     runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install tooling
+        run: python -m pip install --upgrade pip packaging
+
+      - name: Download distribution package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Build a wheel from the sdist
+        run: python -m pip wheel --no-deps dist/*.tar.gz -w sdist-wheel/
+
+      - name: Verify the sdist-built wheel
+        run: python scripts/verify_wheel_contents.py sdist-wheel/*.whl
+
+  install-test:
+    name: Smoke test wheel install
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Download distribution package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Install the wheel into a clean virtual environment
+        # --no-deps: importing the plugin requires a full NetBox installation, which this
+        # job deliberately does not build. It verifies that the distribution installs and
+        # that the package data lands on disk; the test suite in lint-tests.yaml covers
+        # the plugin running inside NetBox.
+        run: |
+          python -m venv "$RUNNER_TEMP/venv"
+          "$RUNNER_TEMP/venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/venv/bin/python" -m pip install --no-deps dist/*.whl
+
+      - name: Verify the installed package data
+        run: |
+          SITE_PACKAGES=$("$RUNNER_TEMP/venv/bin/python" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+          for f in \
+            netbox_branching/__init__.py \
+            netbox_branching/database.py \
+            netbox_branching/migrations/0001_initial.py \
+            netbox_branching/templates/netbox_branching/branch.html \
+            netbox_branching/templates/netbox_branching/buttons/branch_merge.html
+          do
+            test -s "$SITE_PACKAGES/$f" || { echo "missing or empty $f"; exit 1; }
+          done
+          "$RUNNER_TEMP/venv/bin/python" -m pip show netboxlabs-netbox-branching
+
+  publish-testpypi:
+    name: Publish to Test PyPI
+    runs-on: ubuntu-latest
+    needs: [verify-sdist, install-test]
+    # Test PyPI is an opt-in rehearsal channel: only a manual dispatch from a v* tag
+    # publishes here, so the publish path can be exercised against a real index without
+    # touching production. A branch dispatch still runs build and verification as a dry
+    # run, with both publish jobs skipped.
+    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/netboxlabs-netbox-branching
     permissions:
+      contents: read
       id-token: write
     steps:
-    - name: Download distribution package
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      - name: Download distribution package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [verify-sdist, install-test]
+    # A v* tag push is the production path. Test PyPI is a rehearsal rather than a
+    # promotion stage, so it is deliberately absent from this job's needs. The tag format
+    # and the tag-to-wheel version match are enforced in the build job, which fails the
+    # whole run before anything is uploaded.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/netboxlabs-netbox-branching
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distribution package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          print-hash: true
+
+  github-release:
+    name: Create the GitHub release
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download distribution package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create the release if it does not already exist
+        # A tag pushed from a GitHub release already has one, in which case this is a
+        # no-op; a tag pushed from the command line gets a release created here. Any tag
+        # carrying a designation (v1.3.0-beta1, v1.3.0-rc1) is marked as a pre-release.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; uploading distribution files to it"
+            gh release upload "$TAG" dist/* --clobber
+            exit 0
+          fi
+          PRERELEASE=""
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || PRERELEASE="--prerelease"
+          gh release create "$TAG" dist/* \
+            --title "$TAG" \
+            --generate-notes \
+            $PRERELEASE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,21 +2,34 @@ name: Release
 
 # Releases are driven by pushing a v* tag, not by publishing a GitHub release, so that
 # pre-releases (v1.3.0-beta1 -> 1.3.0b1 on PyPI) follow the same automated path as a
-# final release. The GitHub release is created by this workflow after PyPI accepts the
-# upload; see the release job below.
+# final release. Release notes are written by hand: the tag push drafts an empty GitHub
+# release for the notes to be pasted into, or attaches the artifacts to the release if
+# one was created up front. See the github-release job below.
 on:
   push:
     tags:
       - 'v*'
   pull_request:
+    # Only the inputs that can change what gets packaged, so a routine bug fix does not
+    # pay for a release build: the version declarations, and the template and migration
+    # trees that ship as package data and are what verify_wheel_contents.py checks.
     paths:
       - '.github/workflows/release.yaml'
       - 'pyproject.toml'
       - 'scripts/verify_*.py'
-      - 'netbox_branching/**'
+      - 'netbox_branching/__init__.py'
+      - 'netbox_branching/templates/**'
+      - 'netbox_branching/migrations/**'
       - 'README.md'
       - 'LICENSE.md'
   workflow_dispatch:
+
+# Supersede an in-flight run for the same pull request, but never a tag push: a release
+# run that is cancelled halfway may already have uploaded to PyPI, which cannot be redone
+# at the same version.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Least-privilege default for every job; the publish and release jobs widen this themselves.
 permissions:
@@ -26,6 +39,18 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+
+    # Match the validator versions bundled by the pinned publishing action, so twine check
+    # here uses the same code path that PyPI's upload will. Keep these in step when the
+    # pypa/gh-action-pypi-publish pin below moves.
+    env:
+      EXPECTED_TWINE_VERSION: '7.0.0'
+      EXPECTED_PACKAGING_VERSION: '26.2'
+
+    outputs:
+      version: ${{ steps.verify-version.outputs.version }}
+      prerelease: ${{ steps.verify-version.outputs.prerelease }}
+
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +64,14 @@ jobs:
           cache: pip
 
       - name: Install build tooling
-        run: python -m pip install --upgrade build twine packaging
+        run: >-
+          python -m pip install --upgrade
+          build
+          "twine==$EXPECTED_TWINE_VERSION"
+          "packaging==$EXPECTED_PACKAGING_VERSION"
+
+      - name: Check the installed tooling is self-consistent
+        run: python -m pip check
 
       - name: Build sdist and wheel
         run: python -m build
@@ -48,17 +80,23 @@ jobs:
         run: twine check dist/*
 
       - name: Verify the release tag and version declarations
+        id: verify-version
         # Runs here, in the unprivileged build job, against the exact artifacts this run
         # uploads, so neither publish job needs a checkout while holding id-token: write.
         # A failure skips every downstream job. On pull requests and branch dispatches
         # there is no tag, and only pyproject.toml, AppConfig.version and the wheel are
-        # cross-checked.
+        # cross-checked. The script also records the resolved version and whether PEP 440
+        # considers it a pre-release, which the github-release job consumes.
         env:
           TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
           if [[ -n "$TAG" ]]; then
-            [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
-              echo "Ref '$TAG' is not a release tag of the form vX.Y.Z[-designation]"
+            # Deliberately looser than PEP 440 on the separator, so that tagging the
+            # normalised version straight out of pyproject.toml (v1.3.0b1) works as well
+            # as the spelled-out designation (v1.3.0-beta1). verify_release_tag.py is the
+            # authority on whether the version itself parses.
+            [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-]?[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]] || {
+              echo "Ref '$TAG' is not a release tag of the form vX.Y.Z[designation]"
               exit 1
             }
             python scripts/verify_release_tag.py --tag "$TAG" dist/*.whl
@@ -92,9 +130,6 @@ jobs:
           python-version: '3.12'
           cache: pip
 
-      - name: Install tooling
-        run: python -m pip install --upgrade pip packaging
-
       - name: Download distribution package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -112,6 +147,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -127,24 +167,20 @@ jobs:
         # --no-deps: importing the plugin requires a full NetBox installation, which this
         # job deliberately does not build. It verifies that the distribution installs and
         # that the package data lands on disk; the test suite in lint-tests.yaml covers
-        # the plugin running inside NetBox.
+        # the plugin running inside NetBox. --no-compile keeps pip from byte-compiling the
+        # package, so the installed tree can be held to the same no-bytecode rule as the
+        # wheel it came from.
         run: |
           python -m venv "$RUNNER_TEMP/venv"
           "$RUNNER_TEMP/venv/bin/python" -m pip install --upgrade pip
-          "$RUNNER_TEMP/venv/bin/python" -m pip install --no-deps dist/*.whl
+          "$RUNNER_TEMP/venv/bin/python" -m pip install --no-deps --no-compile dist/*.whl
 
       - name: Verify the installed package data
+        # Same checks as the wheel, against the tree pip actually laid down, so the two
+        # cannot drift apart.
         run: |
           SITE_PACKAGES=$("$RUNNER_TEMP/venv/bin/python" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-          for f in \
-            netbox_branching/__init__.py \
-            netbox_branching/database.py \
-            netbox_branching/migrations/0001_initial.py \
-            netbox_branching/templates/netbox_branching/branch.html \
-            netbox_branching/templates/netbox_branching/buttons/branch_merge.html
-          do
-            test -s "$SITE_PACKAGES/$f" || { echo "missing or empty $f"; exit 1; }
-          done
+          python scripts/verify_wheel_contents.py "$SITE_PACKAGES"
           "$RUNNER_TEMP/venv/bin/python" -m pip show netboxlabs-netbox-branching
 
   publish-testpypi:
@@ -203,9 +239,9 @@ jobs:
           print-hash: true
 
   github-release:
-    name: Create the GitHub release
+    name: Draft the GitHub release
     runs-on: ubuntu-latest
-    needs: publish-pypi
+    needs: [build, publish-pypi]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -216,23 +252,25 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-      - name: Create the release if it does not already exist
-        # A tag pushed from a GitHub release already has one, in which case this is a
-        # no-op; a tag pushed from the command line gets a release created here. Any tag
-        # carrying a designation (v1.3.0-beta1, v1.3.0-rc1) is marked as a pre-release.
+      - name: Attach the artifacts to the release, drafting one if needed
+        # Release notes are written by hand, so nothing here generates them. A release
+        # created up front just gets the sdist and wheel attached; a tag pushed from the
+        # command line gets an empty draft to paste the notes into and publish. The
+        # pre-release flag comes from the PEP 440 classification the build job recorded.
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ needs.build.outputs.prerelease }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; uploading distribution files to it"
             gh release upload "$TAG" dist/* --clobber
             exit 0
           fi
-          PRERELEASE=""
-          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || PRERELEASE="--prerelease"
-          gh release create "$TAG" dist/* \
-            --title "$TAG" \
-            --generate-notes \
-            $PRERELEASE
+          FLAGS=()
+          if [[ "$PRERELEASE" == 'true' ]]; then
+            FLAGS+=(--prerelease)
+          fi
+          echo "Drafting release $TAG; the release notes are written by hand before publishing"
+          gh release create "$TAG" dist/* --draft --title "$TAG" --notes '' "${FLAGS[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
 *.pyc
 *.egg-info
+__pycache__/
 .claude/settings.local.json
 .idea/
+
+# Build output
+build/
+dist/
+sdist-wheel/
+
+# mkdocs build output
+site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **`lint-tests.yaml`** — Runs on every PR. Two jobs:
   - *Linting*: Python 3.12, runs `ruff check` and `mkdocs build`.
   - *Tests*: Matrix of Python 3.12, 3.13, 3.14 against a configurable NetBox ref (defaults to `main`). Spins up PostgreSQL + Redis services, installs the plugin, links `testing/configuration.py`, and runs `python netbox/manage.py test netbox_branching.tests --keepdb`.
-- **`release.yaml`** — Driven by pushing a `v*` tag, not by publishing a GitHub release, so pre-releases follow the same automated path as final releases. Builds sdist + wheel with `python -m build`, runs `twine check`, verifies the tag against the version declared in `pyproject.toml`, `AppConfig.version` and the wheel metadata (`scripts/verify_release_tag.py`), verifies the wheel's contents (`scripts/verify_wheel_contents.py`), rebuilds a wheel from the sdist, and smoke-tests a clean `--no-deps` install. Only then does it publish to PyPI using OIDC trusted publishing, and create the GitHub release (marked as a pre-release for any tag carrying a designation) if the tag doesn't already have one. Also runs — build and verification only, no publish — on pull requests that touch packaging inputs, which catches a version bump applied to only one of the two declaration sites. A `workflow_dispatch` from a `v*` tag publishes to Test PyPI instead, as an opt-in rehearsal.
+- **`release.yaml`** — Driven by pushing a `v*` tag, not by publishing a GitHub release, so pre-releases follow the same automated path as final releases. Builds sdist + wheel with `python -m build`, runs `twine check`, verifies the tag against the version declared in `pyproject.toml`, `AppConfig.version` and the wheel metadata (`scripts/verify_release_tag.py`), verifies the wheel's contents (`scripts/verify_wheel_contents.py`), rebuilds a wheel from the sdist, and smoke-tests a clean `--no-deps` install whose installed tree is held to the same content checks as the wheel. Only then does it publish to PyPI using OIDC trusted publishing and attach the artifacts to the GitHub release, drafting an empty one (marked as a pre-release when PEP 440 says the version is one) if the tag doesn't already have a release. Release notes are never generated — they are written by hand. Also runs — build and verification only, no publish — on pull requests that touch packaging inputs, which catches a version bump applied to only one of the two declaration sites. A `workflow_dispatch` from a `v*` tag publishes to Test PyPI instead, as an opt-in rehearsal.
 - **`claude.yaml`** — Claude Code automation hook; triggers on issue/PR comments mentioning `@claude`.
 
 ## Common Tasks
@@ -281,17 +281,18 @@ GitHub Actions workflows in `.github/workflows/`:
 
 1. Bump `version` in both `pyproject.toml` and `netbox_branching/__init__.py`. The two must agree — `release.yaml` fails the build if they don't, on release PRs as well as on the tag itself.
 2. Update `docs/changelog.md`.
-3. Push a `vX.Y.Z` tag. `release.yaml` builds, verifies, publishes to PyPI, and creates the GitHub release.
+3. Push a `vX.Y.Z` tag. `release.yaml` builds, verifies, publishes to PyPI, and attaches the sdist and wheel to the GitHub release.
+4. Write the release notes. If the release was created up front, the tag push just attaches the artifacts to it; if the tag was pushed on its own, the workflow leaves an empty draft release to paste the notes into and publish. Nothing is ever generated from commit messages.
 
-Tags must match `vX.Y.Z[-designation]`. The designation is what makes a pre-release, and it is compared after PEP 440 normalisation, so a beta is cut by setting the version to `1.3.0b1` in both files and pushing `v1.3.0-beta1`:
+Tags must match `vX.Y.Z[designation]`. The designation is what makes a pre-release, and versions are compared after PEP 440 normalisation, so a beta is cut by setting the version to `1.3.0b1` in both files and pushing either spelling of the tag:
 
 ```
-git tag v1.3.0-beta1 && git push origin v1.3.0-beta1
+git tag v1.3.0-beta1 && git push origin v1.3.0-beta1   # or: git tag v1.3.0b1
 ```
 
-PyPI receives `1.3.0b1`, which `pip install netboxlabs-netbox-branching` skips unless the user opts in with `--pre` or pins the exact version, and the GitHub release is marked as a pre-release automatically.
+PyPI receives `1.3.0b1`, which `pip install netboxlabs-netbox-branching` skips unless the user opts in with `--pre` or pins the exact version, and the draft GitHub release is marked as a pre-release automatically.
 
-To rehearse a publish without touching production PyPI, run the workflow manually (`workflow_dispatch`) against the tag; that route publishes to Test PyPI and requires a trusted publisher configured there for this project.
+To rehearse a publish without touching production PyPI, run the workflow manually (`workflow_dispatch`) against the tag; that route publishes to Test PyPI and requires a trusted publisher configured there for this project. Because the Run-workflow button is populated from the default branch, that route is only available once this workflow is on `main`.
 
 ## Conventions and Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,9 @@ Defer all version pins to `pyproject.toml` and `netbox_branching/__init__.py`.
 │   └── using-branches/        — User guides.
 ├── testing/
 │   └── configuration.py       — NetBox config used by the test workflow.
+├── scripts/                   — Packaging verification scripts run by release.yaml.
+│   ├── verify_release_tag.py  — Tag ↔ pyproject ↔ AppConfig ↔ wheel version consistency.
+│   └── verify_wheel_contents.py — Wheel ships templates/migrations, not tests or bytecode.
 ├── .github/workflows/         — lint-tests.yaml, release.yaml, claude.yaml.
 ├── AGENTS.md                  — This file.
 ├── CLAUDE.md                  — Shim that pulls in this file.
@@ -238,7 +241,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **`lint-tests.yaml`** — Runs on every PR. Two jobs:
   - *Linting*: Python 3.12, runs `ruff check` and `mkdocs build`.
   - *Tests*: Matrix of Python 3.12, 3.13, 3.14 against a configurable NetBox ref (defaults to `main`). Spins up PostgreSQL + Redis services, installs the plugin, links `testing/configuration.py`, and runs `python netbox/manage.py test netbox_branching.tests --keepdb`.
-- **`release.yaml`** — Runs on published GitHub releases. Builds sdist + wheel with `python -m build`, then publishes to PyPI using OIDC trusted publishing.
+- **`release.yaml`** — Driven by pushing a `v*` tag, not by publishing a GitHub release, so pre-releases follow the same automated path as final releases. Builds sdist + wheel with `python -m build`, runs `twine check`, verifies the tag against the version declared in `pyproject.toml`, `AppConfig.version` and the wheel metadata (`scripts/verify_release_tag.py`), verifies the wheel's contents (`scripts/verify_wheel_contents.py`), rebuilds a wheel from the sdist, and smoke-tests a clean `--no-deps` install. Only then does it publish to PyPI using OIDC trusted publishing, and create the GitHub release (marked as a pre-release for any tag carrying a designation) if the tag doesn't already have one. Also runs — build and verification only, no publish — on pull requests that touch packaging inputs, which catches a version bump applied to only one of the two declaration sites. A `workflow_dispatch` from a `v*` tag publishes to Test PyPI instead, as an opt-in rehearsal.
 - **`claude.yaml`** — Claude Code automation hook; triggers on issue/PR comments mentioning `@claude`.
 
 ## Common Tasks
@@ -276,9 +279,19 @@ GitHub Actions workflows in `.github/workflows/`:
 
 ### Cut a release
 
-1. Bump `version` in both `pyproject.toml` and `netbox_branching/__init__.py`.
+1. Bump `version` in both `pyproject.toml` and `netbox_branching/__init__.py`. The two must agree — `release.yaml` fails the build if they don't, on release PRs as well as on the tag itself.
 2. Update `docs/changelog.md`.
-3. Tag and publish a GitHub release. `release.yaml` builds and publishes to PyPI.
+3. Push a `vX.Y.Z` tag. `release.yaml` builds, verifies, publishes to PyPI, and creates the GitHub release.
+
+Tags must match `vX.Y.Z[-designation]`. The designation is what makes a pre-release, and it is compared after PEP 440 normalisation, so a beta is cut by setting the version to `1.3.0b1` in both files and pushing `v1.3.0-beta1`:
+
+```
+git tag v1.3.0-beta1 && git push origin v1.3.0-beta1
+```
+
+PyPI receives `1.3.0b1`, which `pip install netboxlabs-netbox-branching` skips unless the user opts in with `--pre` or pins the exact version, and the GitHub release is marked as a pre-release automatically.
+
+To rehearse a publish without touching production PyPI, run the workflow manually (`workflow_dispatch`) against the tag; that route publishes to Test PyPI and requires a trusted publisher configured there for this project.
 
 ## Conventions and Patterns
 

--- a/scripts/verify_release_tag.py
+++ b/scripts/verify_release_tag.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Verify the release tag and the version declarations all agree with the built wheel.
+
+Usage: verify_release_tag.py [--tag <git-ref-or-tag>] <wheel>
+
+The plugin declares its version in two places which must stay in lockstep:
+
+  * ``version`` in pyproject.toml — what ends up in the distribution metadata
+  * ``AppConfig.version`` in netbox_branching/__init__.py — what NetBox displays
+
+With ``--tag``, the git tag being released is checked against both as well. Versions
+are compared after PEP 440 normalisation, so the tag ``v1.2.0-beta1``, the pyproject
+version ``1.2.0b1`` and the AppConfig version ``1.2.0-beta1`` are all considered equal.
+
+Without ``--tag`` (pull requests, branch dispatches) the tag comparison is skipped and
+only the two in-repo declarations are checked against the wheel.
+"""
+
+import argparse
+import re
+import sys
+import tomllib
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / 'pyproject.toml'
+APPCONFIG = REPO_ROOT / 'netbox_branching' / '__init__.py'
+
+APPCONFIG_VERSION_RE = re.compile(r"^\s*version\s*=\s*['\"]([^'\"]+)['\"]", re.MULTILINE)
+
+
+def wheel_version(wheel_path):
+    """Return the Version metadata declared by a built wheel."""
+    with zipfile.ZipFile(wheel_path) as archive:
+        meta_name = next(name for name in archive.namelist() if name.endswith('.dist-info/METADATA'))
+        metadata = Parser().parsestr(archive.read(meta_name).decode())
+    return metadata['Version']
+
+
+def pyproject_version():
+    """Return the version declared in pyproject.toml."""
+    with PYPROJECT.open('rb') as f:
+        return tomllib.load(f)['project']['version']
+
+
+def appconfig_version():
+    """Return AppConfig.version from the plugin package, without importing Django."""
+    match = APPCONFIG_VERSION_RE.search(APPCONFIG.read_text())
+    if match is None:
+        raise SystemExit(f'Could not find a version declaration in {APPCONFIG}')
+    return match.group(1)
+
+
+def normalize(label, value):
+    """PEP 440-normalise a version string, stripping a leading 'v' and any ref prefix."""
+    version = value.rsplit('/', 1)[-1].removeprefix('v')
+    try:
+        return str(Version(version))
+    except InvalidVersion:
+        raise SystemExit(f'{label} is not a valid PEP 440 version: {value}') from None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--tag', help='the git ref or tag being released (e.g. v1.2.0 or v1.2.0-beta1)')
+    parser.add_argument('wheel', help='path to the built wheel')
+    args = parser.parse_args(argv)
+
+    versions = {
+        'wheel metadata': normalize('wheel metadata', wheel_version(args.wheel)),
+        'pyproject.toml': normalize('pyproject.toml', pyproject_version()),
+        'AppConfig.version': normalize('AppConfig.version', appconfig_version()),
+    }
+    if args.tag:
+        versions['git tag'] = normalize('git tag', args.tag)
+
+    for source, version in versions.items():
+        print(f'{source}: {version}')
+
+    if len(set(versions.values())) > 1:
+        print('\nVersion mismatch: every source above must declare the same version.')
+        return 1
+
+    version = next(iter(versions.values()))
+    if Version(version).is_prerelease:
+        print(f'\nOK: {version} (pre-release)')
+    else:
+        print(f'\nOK: {version}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/verify_release_tag.py
+++ b/scripts/verify_release_tag.py
@@ -14,10 +14,17 @@ version ``1.2.0b1`` and the AppConfig version ``1.2.0-beta1`` are all considered
 
 Without ``--tag`` (pull requests, branch dispatches) the tag comparison is skipped and
 only the two in-repo declarations are checked against the wheel.
+
+When run under GitHub Actions, the resolved version and whether PEP 440 classifies it as
+a pre-release are written to ``$GITHUB_OUTPUT`` as ``version`` and ``prerelease``, so the
+release job does not have to re-derive either.
+
+Requires Python 3.11 or later (tomllib). The release workflow runs it on 3.12.
 """
 
 import argparse
-import re
+import ast
+import os
 import sys
 import tomllib
 import zipfile
@@ -30,13 +37,16 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = REPO_ROOT / 'pyproject.toml'
 APPCONFIG = REPO_ROOT / 'netbox_branching' / '__init__.py'
 
-APPCONFIG_VERSION_RE = re.compile(r"^\s*version\s*=\s*['\"]([^'\"]+)['\"]", re.MULTILINE)
-
 
 def wheel_version(wheel_path):
     """Return the Version metadata declared by a built wheel."""
     with zipfile.ZipFile(wheel_path) as archive:
-        meta_name = next(name for name in archive.namelist() if name.endswith('.dist-info/METADATA'))
+        meta_name = next(
+            (name for name in archive.namelist() if name.endswith('.dist-info/METADATA')),
+            None,
+        )
+        if meta_name is None:
+            raise SystemExit(f'{wheel_path} contains no .dist-info/METADATA')
         metadata = Parser().parsestr(archive.read(meta_name).decode())
     return metadata['Version']
 
@@ -48,20 +58,37 @@ def pyproject_version():
 
 
 def appconfig_version():
-    """Return AppConfig.version from the plugin package, without importing Django."""
-    match = APPCONFIG_VERSION_RE.search(APPCONFIG.read_text())
-    if match is None:
-        raise SystemExit(f'Could not find a version declaration in {APPCONFIG}')
-    return match.group(1)
+    """Return AppConfig.version from the plugin package, without importing Django.
+
+    Matched on the parse tree rather than by pattern, so the neighbouring min_version and
+    max_version declarations cannot be picked up by accident.
+    """
+    tree = ast.parse(APPCONFIG.read_text())
+    for class_def in (node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)):
+        for statement in class_def.body:
+            if not isinstance(statement, ast.Assign) or not isinstance(statement.value, ast.Constant):
+                continue
+            if any(isinstance(t, ast.Name) and t.id == 'version' for t in statement.targets):
+                return statement.value.value
+    raise SystemExit(f'Could not find a version declaration in {APPCONFIG}')
 
 
 def normalize(label, value):
     """PEP 440-normalise a version string, stripping a leading 'v' and any ref prefix."""
-    version = value.rsplit('/', 1)[-1].removeprefix('v')
+    version = str(value).rsplit('/', 1)[-1].removeprefix('v')
     try:
         return str(Version(version))
     except InvalidVersion:
         raise SystemExit(f'{label} is not a valid PEP 440 version: {value}') from None
+
+
+def emit_github_output(**values):
+    """Record step outputs when running under GitHub Actions; a no-op elsewhere."""
+    path = os.environ.get('GITHUB_OUTPUT')
+    if not path:
+        return
+    with open(path, 'a') as f:
+        f.writelines(f'{key}={value}\n' for key, value in values.items())
 
 
 def main(argv=None):
@@ -86,10 +113,10 @@ def main(argv=None):
         return 1
 
     version = next(iter(versions.values()))
-    if Version(version).is_prerelease:
-        print(f'\nOK: {version} (pre-release)')
-    else:
-        print(f'\nOK: {version}')
+    prerelease = Version(version).is_prerelease
+    emit_github_output(version=version, prerelease=str(prerelease).lower())
+
+    print(f'\nOK: {version} (pre-release)' if prerelease else f'\nOK: {version}')
     return 0
 
 

--- a/scripts/verify_wheel_contents.py
+++ b/scripts/verify_wheel_contents.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Verify a built wheel ships the runtime data NetBox needs and nothing it shouldn't.
+
+Usage: verify_wheel_contents.py <wheel>
+
+The wheel's contents come entirely from the ``package-data`` glob in pyproject.toml, so
+a packaging change can silently drop the templates (leaving a plugin that installs fine
+and then 500s on every view) or sweep in artefacts from a dirty working tree. Both
+failure modes are caught here, before anything is published.
+"""
+
+import sys
+import zipfile
+from pathlib import PurePosixPath
+
+PACKAGE = 'netbox_branching'
+
+# Runtime-critical files. Templates are loaded by path at render time and migrations by
+# name, so neither is exercised by an import check — they have to be verified as data.
+REQUIRED_FILES = {
+    f'{PACKAGE}/__init__.py',
+    f'{PACKAGE}/database.py',
+    f'{PACKAGE}/middleware.py',
+    f'{PACKAGE}/utilities.py',
+    f'{PACKAGE}/migrations/0001_initial.py',
+    f'{PACKAGE}/templates/{PACKAGE}/branch.html',
+}
+REQUIRED_PREFIXES = (
+    f'{PACKAGE}/api/',
+    f'{PACKAGE}/forms/',
+    f'{PACKAGE}/merge_strategies/',
+    f'{PACKAGE}/migrations/',
+    f'{PACKAGE}/models/',
+    f'{PACKAGE}/tables/',
+    f'{PACKAGE}/templates/{PACKAGE}/',
+    f'{PACKAGE}/templates/{PACKAGE}/buttons/',
+    f'{PACKAGE}/templates/{PACKAGE}/inc/',
+    f'{PACKAGE}/templatetags/',
+)
+
+# Never ship these. The test suite is excluded via exclude-package-data and needs a full
+# NetBox checkout to run; compiled bytecode and editable-install leftovers only appear
+# when a build is run over a dirty tree.
+FORBIDDEN_PREFIXES = (f'{PACKAGE}/tests/',)
+FORBIDDEN_SEGMENTS = (
+    '__pycache__',
+    '.pytest_cache',
+    '.ruff_cache',
+)
+FORBIDDEN_SEGMENT_SUFFIXES = ('.egg-info',)
+
+
+def members(wheel_path):
+    with zipfile.ZipFile(wheel_path) as archive:
+        return [name for name in archive.namelist() if not name.endswith('/')]
+
+
+def main(argv):
+    if len(argv) != 2:
+        print('usage: verify_wheel_contents.py <wheel>')
+        return 2
+    names = members(argv[1])
+    errors = []
+
+    errors += [f'missing required file: {name}' for name in sorted(REQUIRED_FILES) if name not in names]
+    errors += [
+        f'no files found under required prefix: {prefix}'
+        for prefix in REQUIRED_PREFIXES
+        if not any(name.startswith(prefix) for name in names)
+    ]
+
+    for name in sorted(names):
+        if name.startswith(FORBIDDEN_PREFIXES):
+            errors.append(f'unexpected file: {name}')
+        elif any(
+            segment in FORBIDDEN_SEGMENTS or segment.endswith(FORBIDDEN_SEGMENT_SUFFIXES)
+            for segment in PurePosixPath(name).parts
+        ):
+            errors.append(f'build artefact leaked into the wheel: {name}')
+        elif name.endswith(('.pyc', '.pyo')):
+            errors.append(f'compiled bytecode leaked into the wheel: {name}')
+
+    if errors:
+        print(f'{argv[1]} failed verification:')
+        for error in errors:
+            print(f'  - {error}')
+        return 1
+
+    print(f'OK: {argv[1]} contains {len(names)} members and passes all checks')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/scripts/verify_wheel_contents.py
+++ b/scripts/verify_wheel_contents.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
 """Verify a built wheel ships the runtime data NetBox needs and nothing it shouldn't.
 
-Usage: verify_wheel_contents.py <wheel>
+Usage: verify_wheel_contents.py <wheel-or-installed-directory>
 
 The wheel's contents come entirely from the ``package-data`` glob in pyproject.toml, so
 a packaging change can silently drop the templates (leaving a plugin that installs fine
 and then 500s on every view) or sweep in artefacts from a dirty working tree. Both
 failure modes are caught here, before anything is published.
+
+Passing a directory instead of a wheel applies the same checks to the package tree under
+it, which is how the install smoke test holds a ``pip install``ed copy to the same rules
+without keeping a second list of expected files. That install must use ``--no-compile``,
+since byte-compiling the package would trip the no-bytecode check below.
 """
 
 import sys
 import zipfile
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 PACKAGE = 'netbox_branching'
 
@@ -35,6 +40,9 @@ REQUIRED_PREFIXES = (
     f'{PACKAGE}/templates/{PACKAGE}/',
     f'{PACKAGE}/templates/{PACKAGE}/buttons/',
     f'{PACKAGE}/templates/{PACKAGE}/inc/',
+    # Widget templates are named by Widget.template_name (see forms/misc.py) and are as
+    # load-bearing as the view templates.
+    f'{PACKAGE}/templates/{PACKAGE}/widgets/',
     f'{PACKAGE}/templatetags/',
 )
 
@@ -50,14 +58,19 @@ FORBIDDEN_SEGMENTS = (
 FORBIDDEN_SEGMENT_SUFFIXES = ('.egg-info',)
 
 
-def members(wheel_path):
-    with zipfile.ZipFile(wheel_path) as archive:
+def members(target):
+    """Return the package-relative file list of a wheel, or of an installed package tree."""
+    path = Path(target)
+    if path.is_dir():
+        # Scoped to the package so that the rest of site-packages is not swept in.
+        return [str(p.relative_to(path).as_posix()) for p in (path / PACKAGE).rglob('*') if p.is_file()]
+    with zipfile.ZipFile(path) as archive:
         return [name for name in archive.namelist() if not name.endswith('/')]
 
 
 def main(argv):
     if len(argv) != 2:
-        print('usage: verify_wheel_contents.py <wheel>')
+        print('usage: verify_wheel_contents.py <wheel-or-installed-directory>')
         return 2
     names = members(argv[1])
     errors = []
@@ -76,9 +89,9 @@ def main(argv):
             segment in FORBIDDEN_SEGMENTS or segment.endswith(FORBIDDEN_SEGMENT_SUFFIXES)
             for segment in PurePosixPath(name).parts
         ):
-            errors.append(f'build artefact leaked into the wheel: {name}')
+            errors.append(f'unexpected build artefact: {name}')
         elif name.endswith(('.pyc', '.pyo')):
-            errors.append(f'compiled bytecode leaked into the wheel: {name}')
+            errors.append(f'unexpected compiled bytecode: {name}')
 
     if errors:
         print(f'{argv[1]} failed verification:')
@@ -86,7 +99,7 @@ def main(argv):
             print(f'  - {error}')
         return 1
 
-    print(f'OK: {argv[1]} contains {len(names)} members and passes all checks')
+    print(f'OK: {argv[1]} contains {len(names)} package files and passes all checks')
     return 0
 
 


### PR DESCRIPTION
### Fixes: #634

Switch release.yaml from triggering on release: published to triggering on a v* tag push, accepting tags of the form vX.Y.Z[-designation] so v1.3.0-beta1 publishes as 1.3.0b1. Add packaging verification ahead of the upload, plus a wheel-contents check that the templates and migrations shipped

After PyPI accepts the upload, create the GitHub release if the tag doesn't already have one, marking any designated tag as a pre-release. Add an opt-in Test PyPI route via manual dispatch for rehearsing a publish.