### PR TITLE
Add Suspected Cause and Proposed Fix fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yaml
@@ -48,3 +48,13 @@ body:
       placeholder: A TypeError exception was raised
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Suspected Cause
+      description: >
+        If you have identified the likely root cause(s), please detail your findings here (optional).
+  - type: textarea
+    attributes:
+      label: Proposed Fix
+      description: >
+        If you would like to propose a specific fix likely to resolve this issue, please describe it here (optional).


### PR DESCRIPTION
Adds the optional **Suspected Cause** and **Proposed Fix** textarea fields to the bug report issue template, mirroring the change recently made to the NetBox core template. These give reporters an opportunity to share root cause analysis and a proposed remediation when they have one, without making either mandatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)