### PR TITLE
Fixes: #650 - Fix ObjectChange.undo() bypassing model save() on non-MPTT restore

### DIFF
--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.postgres.fields import ArrayField
 from django.db import DEFAULT_DB_ALIAS, models
 from django.urls import reverse
+from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 from mptt.models import MPTTModel
 from netbox.models.features import ChangeLoggingMixin
@@ -36,9 +37,24 @@ def _snapshot_changelog_timestamps(instance):
     return instance.created, instance.last_updated
 
 
+def _prechange_changelog_timestamps(instance, payload):
+    """Read created/last_updated from a raw (un-cleaned) ObjectChange payload.
+    diff_exclude_fields() strips both from the *_clean view used for diffing
+    and deserializing, so a deserialized instance never has them regardless of
+    what the change actually recorded -- but the raw JSON payload still does.
+    None for a model without these fields."""
+    if not isinstance(instance, ChangeLoggingMixin):
+        return None
+    payload = payload or {}
+    return (
+        parse_datetime(payload['created']) if payload.get('created') else None,
+        parse_datetime(payload['last_updated']) if payload.get('last_updated') else None,
+    )
+
+
 def _restore_changelog_timestamps(instance, snapshot, using):
-    """Write a _snapshot_changelog_timestamps() snapshot back after a real
-    save(), via a targeted update() rather than another save()."""
+    """Write a timestamp snapshot back after a real save(), via a targeted
+    update() rather than another save()."""
     if snapshot is None:
         return
     created, last_updated = snapshot
@@ -115,29 +131,31 @@ class ObjectChange(ObjectChange_):
             # with update_fields that matches zero rows and raises NotUpdated. Applying a
             # CREATE change is always an INSERT, so force_insert is correct here. (#610)
             #
-            # A model with its own deserialize_object() hook (e.g. netbox_custom_objects')
-            # defines its own save()/M2M contract on the returned wrapper -- trust it
-            # rather than reaching into a wrapper shape it doesn't guarantee.
-            #
-            # Otherwise, every model is created through its own save(), with M2M data
-            # and change-log timestamps reapplied afterward (see the comment on the
-            # equivalent undo() path below for why: DeserializedObject.save() bypasses
-            # both, and real save() bypasses timestamps the other way).
+            # `instance.m2m_data` is Django's own DeserializedObject attribute -- its
+            # absence means the model's deserialize_object() hook returns a
+            # self-managing wrapper (e.g. netbox_custom_objects') with its own
+            # save()/M2M contract, so trust it rather than reaching into a shape it
+            # doesn't guarantee. Its presence means a plain DeserializedObject, whether
+            # from the generic deserialize_object() utility or from a hook that (like
+            # Cable's) only pre-populates extra attributes before returning one -- both
+            # need the same raw-save-bypass fix as the MPTT branch: must NOT go through
+            # DeserializedObject.save() (bypasses model-defined save() and
+            # auto_now/auto_now_add), but a real save() on an adding instance
+            # re-triggers auto_now/auto_now_add itself, so restore created/last_updated
+            # afterward too.
+            timestamps = _snapshot_changelog_timestamps(instance.object)
             if isinstance(instance.object, MPTTModel):
-                timestamps = _snapshot_changelog_timestamps(instance.object)
                 clear_mptt_fields(instance.object)
                 instance.object.save(using=using, force_insert=True)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
-                _restore_changelog_timestamps(instance.object, timestamps, using)
-            elif hasattr(model, 'deserialize_object'):
-                instance.save(using=using)
-            else:
-                timestamps = _snapshot_changelog_timestamps(instance.object)
+            elif hasattr(instance, 'm2m_data'):
                 instance.object.save(using=using)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
-                _restore_changelog_timestamps(instance.object, timestamps, using)
+            else:
+                instance.save(using=using)
+            _restore_changelog_timestamps(instance.object, timestamps, using)
 
         # Modifying an object
         elif self.action == ObjectChangeActionChoices.ACTION_UPDATE:
@@ -220,21 +238,21 @@ class ObjectChange(ObjectChange_):
             # bypassing any model-defined save() (e.g. schema DDL a save() override applies)
             # and skipping auto_now/auto_now_add. But a real save() on an adding instance
             # re-triggers auto_now/auto_now_add itself, overwriting created/last_updated
-            # with the current time instead of what the change-log payload captured (or
-            # left unset) -- hence the explicit snapshot/restore around it.
+            # with the current time -- restore the *original* values afterward, sourced
+            # from the raw prechange_data (diff_exclude_fields() strips them from
+            # prechange_data_clean, which is what `instance` was deserialized from, so
+            # they're never set on it in the first place).
+            timestamps = _prechange_changelog_timestamps(instance, self.prechange_data)
             if isinstance(instance, MPTTModel):
-                timestamps = _snapshot_changelog_timestamps(instance)
                 clear_mptt_fields(instance)
                 instance.save(using=using, force_insert=True)
                 for accessor_name, object_list in (deserialized.m2m_data or {}).items():
                     getattr(instance, accessor_name).set(object_list)
-                _restore_changelog_timestamps(instance, timestamps, using)
             else:
-                timestamps = _snapshot_changelog_timestamps(instance)
                 instance.save(using=using)
                 for accessor_name, object_list in (deserialized.m2m_data or {}).items():
                     getattr(instance, accessor_name).set(object_list)
-                _restore_changelog_timestamps(instance, timestamps, using)
+            _restore_changelog_timestamps(instance, timestamps, using)
 
     undo.alters_data = True
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -175,20 +175,14 @@ class ObjectChange(ObjectChange_):
             # instance, which bypasses DeserializedObject's M2M handling, so — exactly as the
             # MPTT create path above does — reassign the M2M data explicitly. (#531, #610)
             #
-            # Every other model (including NetBox 4.7+ ltree models, whose path/sort_path
-            # columns are recomputed server-side by triggers) is restored the same way:
-            # through the model's own save(), with M2M data reapplied afterward. This must
-            # NOT go through DeserializedObject.save() -- that calls Model.save_base(...,
-            # raw=True) directly, which per Django's own docs "bypasses any model-defined
-            # save" and skips auto_now/auto_now_add population. Both are relied on
-            # elsewhere: a model can exclude an auto_now field from serialize_object() to
-            # keep it out of change-log diffs (NetBox core does this for ConfigContext's
-            # cache fields) and count on save() to repopulate it on any real save, and a
-            # model's save() override can perform side effects a restore still needs to
-            # run (netbox_custom_objects.CustomObjectTypeField.save() applies the schema
-            # DDL that (re)creates a field's physical column). A raw save_base() silently
-            # skips both, leaving excluded NOT NULL auto_now fields unpopulated and any
-            # such side effects un-run.
+            # Every other model is restored the same way: through the model's own save(),
+            # with M2M data reapplied afterward. Must NOT go through DeserializedObject.save()
+            # -- it calls Model.save_base(..., raw=True), which bypasses any model-defined
+            # save() and skips auto_now/auto_now_add population. Both are relied on
+            # elsewhere (e.g. an auto_now field excluded from serialize_object() to keep it
+            # out of change-log diffs, or a save() override with side effects a restore
+            # still needs), so a raw save_base() can leave excluded NOT NULL fields
+            # unpopulated or skip those side effects entirely.
             if isinstance(instance, MPTTModel):
                 clear_mptt_fields(instance)
                 instance.save(using=using, force_insert=True)

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -176,17 +176,28 @@ class ObjectChange(ObjectChange_):
             # MPTT create path above does — reassign the M2M data explicitly. (#531, #610)
             #
             # Every other model (including NetBox 4.7+ ltree models, whose path/sort_path
-            # columns are recomputed server-side by triggers) is restored through
-            # DeserializedObject.save(), which persists the object and re-establishes its
-            # M2M relationships. Saving the raw instance here instead would silently drop
-            # M2M data (e.g. tags on a reverted ModuleBay).
+            # columns are recomputed server-side by triggers) is restored the same way:
+            # through the model's own save(), with M2M data reapplied afterward. This must
+            # NOT go through DeserializedObject.save() -- that calls Model.save_base(...,
+            # raw=True) directly, which per Django's own docs "bypasses any model-defined
+            # save" and skips auto_now/auto_now_add population. Both are relied on
+            # elsewhere: a model can exclude an auto_now field from serialize_object() to
+            # keep it out of change-log diffs (NetBox core does this for ConfigContext's
+            # cache fields) and count on save() to repopulate it on any real save, and a
+            # model's save() override can perform side effects a restore still needs to
+            # run (netbox_custom_objects.CustomObjectTypeField.save() applies the schema
+            # DDL that (re)creates a field's physical column). A raw save_base() silently
+            # skips both, leaving excluded NOT NULL auto_now fields unpopulated and any
+            # such side effects un-run.
             if isinstance(instance, MPTTModel):
                 clear_mptt_fields(instance)
                 instance.save(using=using, force_insert=True)
                 for accessor_name, object_list in (deserialized.m2m_data or {}).items():
                     getattr(instance, accessor_name).set(object_list)
             else:
-                deserialized.save(using=using)
+                instance.save(using=using)
+                for accessor_name, object_list in (deserialized.m2m_data or {}).items():
+                    getattr(instance, accessor_name).set(object_list)
 
     undo.alters_data = True
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -9,6 +9,7 @@ from django.db import DEFAULT_DB_ALIAS, models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from mptt.models import MPTTModel
+from netbox.models.features import ChangeLoggingMixin
 from utilities.querysets import RestrictedQuerySet
 from utilities.serialization import deserialize_object
 
@@ -25,6 +26,34 @@ __all__ = (
     'ChangeDiff',
     'ObjectChange',
 )
+
+
+def _snapshot_changelog_timestamps(instance):
+    """Capture created/last_updated before a real save() can overwrite them.
+    See _restore_changelog_timestamps() for why. Returns None for a model with
+    no such fields, which _restore_changelog_timestamps() treats as a no-op."""
+    if not isinstance(instance, ChangeLoggingMixin):
+        return None
+    return instance.created, instance.last_updated
+
+
+def _restore_changelog_timestamps(instance, snapshot, using):
+    """
+    A real (non-raw) save() re-triggers Django's auto_now/auto_now_add handling for
+    created/last_updated, overwriting whatever the change-log payload captured (or
+    leaving them unset, per ObjectChange.diff_exclude_fields) with the current time.
+    Write the pre-save() values back with a targeted column update -- bypassing
+    save() again -- so calling the model's own save() (needed for side effects like
+    schema DDL) doesn't corrupt NetBox's own change-log timestamps.
+    """
+    if snapshot is None:
+        return
+    created, last_updated = snapshot
+    type(instance)._base_manager.using(using).filter(pk=instance.pk).update(
+        created=created, last_updated=last_updated,
+    )
+    instance.created = created
+    instance.last_updated = last_updated
 
 
 class ObjectChange(ObjectChange_):
@@ -103,17 +132,27 @@ class ObjectChange(ObjectChange_):
             # through the model's own save(), with M2M data reapplied afterward. Must NOT
             # go through DeserializedObject.save() -- see the comment on the equivalent
             # undo() path below for why.
+            #
+            # Either real save() also re-triggers auto_now/auto_now_add on created/
+            # last_updated, discarding whatever the change-log payload captured (or left
+            # unset, per diff_exclude_fields) in favor of the current time. Restore the
+            # pre-save() values afterward so a real save() can run without corrupting
+            # NetBox's own change-log timestamps.
             if isinstance(instance.object, MPTTModel):
+                timestamps = _snapshot_changelog_timestamps(instance.object)
                 clear_mptt_fields(instance.object)
                 instance.object.save(using=using, force_insert=True)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
+                _restore_changelog_timestamps(instance.object, timestamps, using)
             elif hasattr(model, 'deserialize_object'):
                 instance.save(using=using)
             else:
+                timestamps = _snapshot_changelog_timestamps(instance.object)
                 instance.object.save(using=using)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
+                _restore_changelog_timestamps(instance.object, timestamps, using)
 
         # Modifying an object
         elif self.action == ObjectChangeActionChoices.ACTION_UPDATE:
@@ -198,15 +237,23 @@ class ObjectChange(ObjectChange_):
             # out of change-log diffs, or a save() override with side effects a restore
             # still needs), so a raw save_base() can leave excluded NOT NULL fields
             # unpopulated or skip those side effects entirely.
+            #
+            # Either real save() also re-triggers auto_now/auto_now_add on created/
+            # last_updated -- restore the pre-save() values afterward; see
+            # _restore_changelog_timestamps().
             if isinstance(instance, MPTTModel):
+                timestamps = _snapshot_changelog_timestamps(instance)
                 clear_mptt_fields(instance)
                 instance.save(using=using, force_insert=True)
                 for accessor_name, object_list in (deserialized.m2m_data or {}).items():
                     getattr(instance, accessor_name).set(object_list)
+                _restore_changelog_timestamps(instance, timestamps, using)
             else:
+                timestamps = _snapshot_changelog_timestamps(instance)
                 instance.save(using=using)
                 for accessor_name, object_list in (deserialized.m2m_data or {}).items():
                     getattr(instance, accessor_name).set(object_list)
+                _restore_changelog_timestamps(instance, timestamps, using)
 
     undo.alters_data = True
 

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -29,14 +29,6 @@ __all__ = (
 )
 
 
-def _snapshot_changelog_timestamps(instance):
-    """Capture created/last_updated before a real save() overwrites them via
-    auto_now/auto_now_add. None for a model without these fields."""
-    if not isinstance(instance, ChangeLoggingMixin):
-        return None
-    return instance.created, instance.last_updated
-
-
 def _prechange_changelog_timestamps(instance, payload):
     """Read created/last_updated from a raw (un-cleaned) ObjectChange payload.
     diff_exclude_fields() strips both from the *_clean view used for diffing
@@ -130,32 +122,13 @@ class ObjectChange(ObjectChange_):
             # and route it through the "move existing node" path, which forces an UPDATE
             # with update_fields that matches zero rows and raises NotUpdated. Applying a
             # CREATE change is always an INSERT, so force_insert is correct here. (#610)
-            #
-            # `instance.m2m_data` is Django's own DeserializedObject attribute -- its
-            # absence means the model's deserialize_object() hook returns a
-            # self-managing wrapper (e.g. netbox_custom_objects') with its own
-            # save()/M2M contract, so trust it rather than reaching into a shape it
-            # doesn't guarantee. Its presence means a plain DeserializedObject, whether
-            # from the generic deserialize_object() utility or from a hook that (like
-            # Cable's) only pre-populates extra attributes before returning one -- both
-            # need the same raw-save-bypass fix as the MPTT branch: must NOT go through
-            # DeserializedObject.save() (bypasses model-defined save() and
-            # auto_now/auto_now_add), but a real save() on an adding instance
-            # re-triggers auto_now/auto_now_add itself, so restore created/last_updated
-            # afterward too.
-            timestamps = _snapshot_changelog_timestamps(instance.object)
             if isinstance(instance.object, MPTTModel):
                 clear_mptt_fields(instance.object)
                 instance.object.save(using=using, force_insert=True)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
-            elif hasattr(instance, 'm2m_data'):
-                instance.object.save(using=using)
-                for accessor_name, object_list in (instance.m2m_data or {}).items():
-                    getattr(instance.object, accessor_name).set(object_list)
             else:
                 instance.save(using=using)
-            _restore_changelog_timestamps(instance.object, timestamps, using)
 
         # Modifying an object
         elif self.action == ObjectChangeActionChoices.ACTION_UPDATE:

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -92,13 +92,28 @@ class ObjectChange(ObjectChange_):
             # and route it through the "move existing node" path, which forces an UPDATE
             # with update_fields that matches zero rows and raises NotUpdated. Applying a
             # CREATE change is always an INSERT, so force_insert is correct here. (#610)
+            #
+            # A model with its own deserialize_object() hook defines its own save()
+            # contract on the returned wrapper (e.g. netbox_custom_objects' models use
+            # this to run their real save() and reapply M2M data themselves, working
+            # around the same DeserializedObject.save() hazard described below) -- trust
+            # it rather than reaching into a wrapper shape it doesn't guarantee.
+            #
+            # Otherwise (the plain deserialize_object() utility), every model is created
+            # through the model's own save(), with M2M data reapplied afterward. Must NOT
+            # go through DeserializedObject.save() -- see the comment on the equivalent
+            # undo() path below for why.
             if isinstance(instance.object, MPTTModel):
                 clear_mptt_fields(instance.object)
                 instance.object.save(using=using, force_insert=True)
                 for accessor_name, object_list in (instance.m2m_data or {}).items():
                     getattr(instance.object, accessor_name).set(object_list)
-            else:
+            elif hasattr(model, 'deserialize_object'):
                 instance.save(using=using)
+            else:
+                instance.object.save(using=using)
+                for accessor_name, object_list in (instance.m2m_data or {}).items():
+                    getattr(instance.object, accessor_name).set(object_list)
 
         # Modifying an object
         elif self.action == ObjectChangeActionChoices.ACTION_UPDATE:

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -29,23 +29,16 @@ __all__ = (
 
 
 def _snapshot_changelog_timestamps(instance):
-    """Capture created/last_updated before a real save() can overwrite them.
-    See _restore_changelog_timestamps() for why. Returns None for a model with
-    no such fields, which _restore_changelog_timestamps() treats as a no-op."""
+    """Capture created/last_updated before a real save() overwrites them via
+    auto_now/auto_now_add. None for a model without these fields."""
     if not isinstance(instance, ChangeLoggingMixin):
         return None
     return instance.created, instance.last_updated
 
 
 def _restore_changelog_timestamps(instance, snapshot, using):
-    """
-    A real (non-raw) save() re-triggers Django's auto_now/auto_now_add handling for
-    created/last_updated, overwriting whatever the change-log payload captured (or
-    leaving them unset, per ObjectChange.diff_exclude_fields) with the current time.
-    Write the pre-save() values back with a targeted column update -- bypassing
-    save() again -- so calling the model's own save() (needed for side effects like
-    schema DDL) doesn't corrupt NetBox's own change-log timestamps.
-    """
+    """Write a _snapshot_changelog_timestamps() snapshot back after a real
+    save(), via a targeted update() rather than another save()."""
     if snapshot is None:
         return
     created, last_updated = snapshot
@@ -122,22 +115,14 @@ class ObjectChange(ObjectChange_):
             # with update_fields that matches zero rows and raises NotUpdated. Applying a
             # CREATE change is always an INSERT, so force_insert is correct here. (#610)
             #
-            # A model with its own deserialize_object() hook defines its own save()
-            # contract on the returned wrapper (e.g. netbox_custom_objects' models use
-            # this to run their real save() and reapply M2M data themselves, working
-            # around the same DeserializedObject.save() hazard described below) -- trust
-            # it rather than reaching into a wrapper shape it doesn't guarantee.
+            # A model with its own deserialize_object() hook (e.g. netbox_custom_objects')
+            # defines its own save()/M2M contract on the returned wrapper -- trust it
+            # rather than reaching into a wrapper shape it doesn't guarantee.
             #
-            # Otherwise (the plain deserialize_object() utility), every model is created
-            # through the model's own save(), with M2M data reapplied afterward. Must NOT
-            # go through DeserializedObject.save() -- see the comment on the equivalent
-            # undo() path below for why.
-            #
-            # Either real save() also re-triggers auto_now/auto_now_add on created/
-            # last_updated, discarding whatever the change-log payload captured (or left
-            # unset, per diff_exclude_fields) in favor of the current time. Restore the
-            # pre-save() values afterward so a real save() can run without corrupting
-            # NetBox's own change-log timestamps.
+            # Otherwise, every model is created through its own save(), with M2M data
+            # and change-log timestamps reapplied afterward (see the comment on the
+            # equivalent undo() path below for why: DeserializedObject.save() bypasses
+            # both, and real save() bypasses timestamps the other way).
             if isinstance(instance.object, MPTTModel):
                 timestamps = _snapshot_changelog_timestamps(instance.object)
                 clear_mptt_fields(instance.object)
@@ -230,17 +215,13 @@ class ObjectChange(ObjectChange_):
             # MPTT create path above does — reassign the M2M data explicitly. (#531, #610)
             #
             # Every other model is restored the same way: through the model's own save(),
-            # with M2M data reapplied afterward. Must NOT go through DeserializedObject.save()
-            # -- it calls Model.save_base(..., raw=True), which bypasses any model-defined
-            # save() and skips auto_now/auto_now_add population. Both are relied on
-            # elsewhere (e.g. an auto_now field excluded from serialize_object() to keep it
-            # out of change-log diffs, or a save() override with side effects a restore
-            # still needs), so a raw save_base() can leave excluded NOT NULL fields
-            # unpopulated or skip those side effects entirely.
-            #
-            # Either real save() also re-triggers auto_now/auto_now_add on created/
-            # last_updated -- restore the pre-save() values afterward; see
-            # _restore_changelog_timestamps().
+            # with M2M data and change-log timestamps reapplied afterward. Must NOT go
+            # through DeserializedObject.save() -- it calls Model.save_base(..., raw=True),
+            # bypassing any model-defined save() (e.g. schema DDL a save() override applies)
+            # and skipping auto_now/auto_now_add. But a real save() on an adding instance
+            # re-triggers auto_now/auto_now_add itself, overwriting created/last_updated
+            # with the current time instead of what the change-log payload captured (or
+            # left unset) -- hence the explicit snapshot/restore around it.
             if isinstance(instance, MPTTModel):
                 timestamps = _snapshot_changelog_timestamps(instance)
                 clear_mptt_fields(instance)

--- a/netbox_branching/models/changes.py
+++ b/netbox_branching/models/changes.py
@@ -219,12 +219,10 @@ class ObjectChange(ObjectChange_):
             if isinstance(instance, MPTTModel):
                 clear_mptt_fields(instance)
                 instance.save(using=using, force_insert=True)
-                for accessor_name, object_list in (deserialized.m2m_data or {}).items():
-                    getattr(instance, accessor_name).set(object_list)
             else:
                 instance.save(using=using)
-                for accessor_name, object_list in (deserialized.m2m_data or {}).items():
-                    getattr(instance, accessor_name).set(object_list)
+            for accessor_name, object_list in (deserialized.m2m_data or {}).items():
+                getattr(instance, accessor_name).set(object_list)
             _restore_changelog_timestamps(instance, timestamps, using)
 
     undo.alters_data = True

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1078,6 +1078,32 @@ class BaseMergeTests:
         )
         self.assertTrue(Site.objects.filter(id=site_id).exists())
 
+    def test_merge_apply_create_calls_model_save_not_raw_save_base(self):
+        """
+        Creating a new object during merge() must call the object's own save(),
+        not bypass it via DeserializedObject.save() -- the same hazard as
+        ObjectChange.undo(), on ObjectChange.apply()'s CREATE path.
+        """
+        branch = self._create_and_provision_branch()
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with activate_branch(branch), event_tracking(request):
+            site = Site.objects.create(name='Test Site', slug='test-site')
+            site_id = site.id
+
+        original_save = Site.save
+        with unittest.mock.patch.object(Site, 'save', autospec=True, side_effect=original_save) as mock_save:
+            branch.merge(user=self.user, commit=True)
+
+        self.assertTrue(
+            mock_save.called,
+            "Creating an object during merge must call the model's own save(), not bypass it",
+        )
+        self.assertTrue(Site.objects.filter(id=site_id).exists())
+
     def test_merge_many_to_many_tags(self):
         """
         Test adding and removing many-to-many relationships (tags on site).

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1072,41 +1072,13 @@ class BaseMergeTests:
         )
         self.assertTrue(Site.objects.filter(id=site_id).exists())
 
-    def test_merge_create_preserves_created_timestamp(self):
-        """A real save() (needed for save() overrides) also re-triggers
-        auto_now_add, which would otherwise stamp `created` with merge time
-        instead of the branch's actual creation time."""
-        import time
-
-        branch = self._create_and_provision_branch()
-
-        request = RequestFactory().get(reverse('home'))
-        request.id = uuid.uuid4()
-        request.user = self.user
-
-        with activate_branch(branch), event_tracking(request):
-            site = Site.objects.create(name='Test Site', slug='test-site')
-            site_id = site.id
-            created_in_branch = site.created
-
-        # Merge strictly after creation so a stamped-with-merge-time value
-        # would be detectably different from created_in_branch.
-        time.sleep(1.5)
-        branch.merge(user=self.user, commit=True)
-
-        site = Site.objects.get(id=site_id)
-        # Sub-millisecond tolerance for the change-log's JSON round trip
-        # (millisecond precision), which is unrelated to what's under test here.
-        self.assertLess(abs((site.created - created_in_branch).total_seconds()), 0.01)
-
     def test_revert_restore_recovers_original_created_timestamp(self):
-        """Same hazard as test_merge_create_preserves_created_timestamp, on
-        undo()'s restore path: a real save() re-triggers auto_now_add, which
-        would stamp `created` with revert time instead of the object's actual
-        original creation time. The deserialized instance never has `created`
-        set in the first place -- diff_exclude_fields() strips it from
-        prechange_data_clean -- so the fix sources it from the un-cleaned
-        prechange_data instead, which still has it."""
+        """undo()'s restore path calls a real save(), which re-triggers
+        auto_now_add and would stamp `created` with revert time instead of the
+        object's actual original creation time. The deserialized instance
+        never has `created` set in the first place -- diff_exclude_fields()
+        strips it from prechange_data_clean -- so the fix sources it from the
+        un-cleaned prechange_data instead, which still has it."""
         import time
 
         request = RequestFactory().get(reverse('home'))
@@ -1131,79 +1103,6 @@ class BaseMergeTests:
 
         site = Site.objects.get(id=site_id)
         self.assertLess(abs((site.created - original_created).total_seconds()), 0.01)
-
-    def test_merge_cable_created_in_branch_has_terminations(self):
-        """
-        Cable.deserialize_object() (core) is a case flagged in review: it exists
-        for reasons unrelated to this PR's fix (popping a_terminations/
-        b_terminations before deserializing) and returns a plain
-        DeserializedObject, not a self-managing wrapper like
-        netbox_custom_objects' -- so hasattr(model, 'deserialize_object') alone
-        can't distinguish it from that case, which is why the dispatch keys off
-        hasattr(instance, 'm2m_data') instead (see the comment in apply()).
-
-        CableTermination/CablePath creation don't depend on Cable.save() firing
-        correctly during replay either way, since those are independently
-        change-tracked via their own ObjectChange records from the original
-        branch-side save() -- this doesn't regress either way -- but the
-        dispatch fix is still the right one on its own terms.
-        """
-        site = Site.objects.create(name='Cable Site', slug='cable-site')
-        device_a = Device.objects.create(
-            name='Cable Device A', site=site, device_type=self.device_type, role=self.device_role,
-        )
-        device_b = Device.objects.create(
-            name='Cable Device B', site=site, device_type=self.device_type, role=self.device_role,
-        )
-        interface_a = Interface.objects.create(device=device_a, name='eth0', type='1000base-t')
-        interface_b = Interface.objects.create(device=device_b, name='eth0', type='1000base-t')
-        interface_a_id, interface_b_id = interface_a.id, interface_b.id
-
-        branch = self._create_and_provision_branch()
-
-        request = RequestFactory().get(reverse('home'))
-        request.id = uuid.uuid4()
-        request.user = self.user
-
-        with activate_branch(branch), event_tracking(request):
-            cable = Cable(
-                a_terminations=[Interface.objects.get(id=interface_a_id)],
-                b_terminations=[Interface.objects.get(id=interface_b_id)],
-            )
-            cable.save()
-            cable_id = cable.id
-
-        branch.merge(user=self.user, commit=True)
-
-        self.assertTrue(Cable.objects.filter(id=cable_id).exists())
-        self.assertEqual(Interface.objects.get(id=interface_a_id).cable_id, cable_id)
-        self.assertEqual(Interface.objects.get(id=interface_b_id).cable_id, cable_id)
-
-    def test_merge_apply_create_calls_model_save_not_raw_save_base(self):
-        """
-        Creating a new object during merge() must call the object's own save(),
-        not bypass it via DeserializedObject.save() -- the same hazard as
-        ObjectChange.undo(), on ObjectChange.apply()'s CREATE path.
-        """
-        branch = self._create_and_provision_branch()
-
-        request = RequestFactory().get(reverse('home'))
-        request.id = uuid.uuid4()
-        request.user = self.user
-
-        with activate_branch(branch), event_tracking(request):
-            site = Site.objects.create(name='Test Site', slug='test-site')
-            site_id = site.id
-
-        original_save = Site.save
-        with unittest.mock.patch.object(Site, 'save', autospec=True, side_effect=original_save) as mock_save:
-            branch.merge(user=self.user, commit=True)
-
-        self.assertTrue(
-            mock_save.called,
-            "Creating an object during merge must call the model's own save(), not bypass it",
-        )
-        self.assertTrue(Site.objects.filter(id=site_id).exists())
 
     def test_merge_many_to_many_tags(self):
         """

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -2,6 +2,7 @@
 Tests for Branch merge functionality with common base class and iterative merge strategy.
 """
 import unittest
+import unittest.mock
 import uuid
 
 from dcim.models import (
@@ -1011,6 +1012,74 @@ class BaseMergeTests:
         self.assertEqual(restored.count(), 1)
         self.assertEqual(restored.first().name, deleted_bay_name)
         self.assertEqual(set(restored.first().tags.all()), {tag1, tag2})
+
+    def test_merge_revert_restores_deleted_non_mptt_object(self):
+        """
+        Deleting a plain (non-MPTT) object in a branch and then reverting the merge
+        must restore it, including its M2M relationships (e.g. tags).
+        """
+        tag1 = Tag.objects.create(name='Tag 1', slug='tag-1')
+        tag2 = Tag.objects.create(name='Tag 2', slug='tag-2')
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with event_tracking(request):
+            site = Site.objects.create(name='Site 1', slug='site-1')
+            site.tags.add(tag1, tag2)
+        site_id = site.id
+
+        branch = self._create_and_provision_branch()
+
+        with activate_branch(branch), event_tracking(request):
+            Site.objects.get(id=site_id).delete()
+
+        branch.merge(user=self.user, commit=True)
+        self.assertFalse(Site.objects.filter(id=site_id).exists())
+
+        branch.revert(user=self.user, commit=True)
+        restored = Site.objects.filter(id=site_id)
+        self.assertEqual(restored.count(), 1)
+        self.assertEqual(set(restored.first().tags.all()), {tag1, tag2})
+
+    def test_revert_restore_calls_model_save_not_raw_save_base(self):
+        """
+        Restoring a deleted non-MPTT object during revert() must go through the
+        object's own save() method -- not DeserializedObject.save(), which calls
+        Model.save_base(..., raw=True) directly, bypassing any model-defined
+        save() override and auto_now/auto_now_add population. Neither is exercised
+        by NetBox core's own Site model, so this spies on Site.save() directly
+        rather than relying on an observable side effect; the more concrete,
+        production-shaped regression (an excluded auto_now field causing a NOT
+        NULL violation, and a save() override that applies schema DDL) is covered
+        in netbox_custom_objects' own test suite, which depends on this fix.
+        """
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with event_tracking(request):
+            site = Site.objects.create(name='Site 1', slug='site-1')
+        site_id = site.id
+
+        branch = self._create_and_provision_branch()
+
+        with activate_branch(branch), event_tracking(request):
+            Site.objects.get(id=site_id).delete()
+
+        branch.merge(user=self.user, commit=True)
+        self.assertFalse(Site.objects.filter(id=site_id).exists())
+
+        original_save = Site.save
+        with unittest.mock.patch.object(Site, 'save', autospec=True, side_effect=original_save) as mock_save:
+            branch.revert(user=self.user, commit=True)
+
+        self.assertTrue(
+            mock_save.called,
+            "Restoring a deleted object must call the model's own save(), not bypass it",
+        )
+        self.assertTrue(Site.objects.filter(id=site_id).exists())
 
     def test_merge_many_to_many_tags(self):
         """

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1078,6 +1078,76 @@ class BaseMergeTests:
         )
         self.assertTrue(Site.objects.filter(id=site_id).exists())
 
+    def test_merge_create_preserves_created_timestamp(self):
+        """
+        Merging a branch-created object must not stamp `created` with the merge
+        time. apply()'s CREATE path now uses a real (non-raw) save() so that
+        save() overrides run (see test_merge_apply_create_calls_model_save_not_
+        raw_save_base above) -- but a real save() on an adding instance also
+        re-triggers auto_now_add, which would silently discard the branch's
+        actual creation time in favor of whatever moment the merge happens to
+        run. #648 restores it explicitly after save().
+        """
+        import time
+
+        branch = self._create_and_provision_branch()
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with activate_branch(branch), event_tracking(request):
+            site = Site.objects.create(name='Test Site', slug='test-site')
+            site_id = site.id
+            created_in_branch = site.created
+
+        # Merge strictly after creation so a stamped-with-merge-time value
+        # would be detectably different from created_in_branch.
+        time.sleep(1.5)
+        branch.merge(user=self.user, commit=True)
+
+        site = Site.objects.get(id=site_id)
+        # Sub-millisecond tolerance for the change-log's JSON round trip
+        # (millisecond precision), which is unrelated to what's under test here.
+        self.assertLess(abs((site.created - created_in_branch).total_seconds()), 0.01)
+
+    def test_revert_restore_does_not_stamp_created_with_revert_time(self):
+        """
+        Reverting a branch-deleted object must not stamp `created` with the
+        revert time, for the same reason as test_merge_create_preserves_
+        created_timestamp above, on undo()'s restore path.
+
+        Note this doesn't assert the *original* created value is restored:
+        ObjectChange.diff_exclude_fields() (core, pre-existing) strips
+        created/last_updated from prechange_data_clean, which is what undo()'s
+        restore path deserializes from -- so the original timestamp isn't
+        available to restore in the first place. What matters here is that a
+        real save() doesn't inject a *wrong*, revert-time value in its place.
+        """
+        import time
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with event_tracking(request):
+            site = Site.objects.create(name='Site 1', slug='site-1')
+        site_id = site.id
+
+        branch = self._create_and_provision_branch()
+
+        with activate_branch(branch), event_tracking(request):
+            Site.objects.get(id=site_id).delete()
+
+        branch.merge(user=self.user, commit=True)
+        self.assertFalse(Site.objects.filter(id=site_id).exists())
+
+        time.sleep(1.5)
+        branch.revert(user=self.user, commit=True)
+
+        site = Site.objects.get(id=site_id)
+        self.assertIsNone(site.created)
+
     def test_merge_apply_create_calls_model_save_not_raw_save_base(self):
         """
         Creating a new object during merge() must call the object's own save(),

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1014,10 +1014,8 @@ class BaseMergeTests:
         self.assertEqual(set(restored.first().tags.all()), {tag1, tag2})
 
     def test_merge_revert_restores_deleted_non_mptt_object(self):
-        """
-        Deleting a plain (non-MPTT) object in a branch and then reverting the merge
-        must restore it, including its M2M relationships (e.g. tags).
-        """
+        """Deleting a non-MPTT object in a branch and reverting the merge
+        must restore it, including M2M relationships (tags)."""
         tag1 = Tag.objects.create(name='Tag 1', slug='tag-1')
         tag2 = Tag.objects.create(name='Tag 2', slug='tag-2')
 
@@ -1044,14 +1042,10 @@ class BaseMergeTests:
         self.assertEqual(set(restored.first().tags.all()), {tag1, tag2})
 
     def test_revert_restore_calls_model_save_not_raw_save_base(self):
-        """
-        Restoring a deleted object during revert() must call the object's own
-        save(), not bypass it via DeserializedObject.save(). Site has no
-        auto_now/save()-override side effect to observe, so this spies on
-        Site.save() directly; the production-shaped regression (an excluded
-        auto_now field, a save() override applying schema DDL) is covered in
-        netbox_custom_objects' own test suite.
-        """
+        """Restore must call the object's own save(), not bypass it via
+        DeserializedObject.save(). Site has no save()-override side effect to
+        observe, so this spies on Site.save() directly; the production-shaped
+        regression is covered in netbox_custom_objects' own test suite."""
         request = RequestFactory().get(reverse('home'))
         request.id = uuid.uuid4()
         request.user = self.user
@@ -1079,15 +1073,9 @@ class BaseMergeTests:
         self.assertTrue(Site.objects.filter(id=site_id).exists())
 
     def test_merge_create_preserves_created_timestamp(self):
-        """
-        Merging a branch-created object must not stamp `created` with the merge
-        time. apply()'s CREATE path now uses a real (non-raw) save() so that
-        save() overrides run (see test_merge_apply_create_calls_model_save_not_
-        raw_save_base above) -- but a real save() on an adding instance also
-        re-triggers auto_now_add, which would silently discard the branch's
-        actual creation time in favor of whatever moment the merge happens to
-        run. #648 restores it explicitly after save().
-        """
+        """A real save() (needed for save() overrides) also re-triggers
+        auto_now_add, which would otherwise stamp `created` with merge time
+        instead of the branch's actual creation time."""
         import time
 
         branch = self._create_and_provision_branch()
@@ -1112,18 +1100,12 @@ class BaseMergeTests:
         self.assertLess(abs((site.created - created_in_branch).total_seconds()), 0.01)
 
     def test_revert_restore_does_not_stamp_created_with_revert_time(self):
-        """
-        Reverting a branch-deleted object must not stamp `created` with the
-        revert time, for the same reason as test_merge_create_preserves_
-        created_timestamp above, on undo()'s restore path.
-
-        Note this doesn't assert the *original* created value is restored:
-        ObjectChange.diff_exclude_fields() (core, pre-existing) strips
-        created/last_updated from prechange_data_clean, which is what undo()'s
-        restore path deserializes from -- so the original timestamp isn't
-        available to restore in the first place. What matters here is that a
-        real save() doesn't inject a *wrong*, revert-time value in its place.
-        """
+        """Same hazard as test_merge_create_preserves_created_timestamp, on
+        undo()'s restore path. Asserts None rather than the original created
+        value: ObjectChange.diff_exclude_fields() (core, pre-existing) strips
+        created/last_updated from prechange_data_clean before undo() ever sees
+        it, so the original timestamp isn't recoverable here regardless -- what
+        this guards is that a real save() doesn't inject a wrong one instead."""
         import time
 
         request = RequestFactory().get(reverse('home'))

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1099,13 +1099,14 @@ class BaseMergeTests:
         # (millisecond precision), which is unrelated to what's under test here.
         self.assertLess(abs((site.created - created_in_branch).total_seconds()), 0.01)
 
-    def test_revert_restore_does_not_stamp_created_with_revert_time(self):
+    def test_revert_restore_recovers_original_created_timestamp(self):
         """Same hazard as test_merge_create_preserves_created_timestamp, on
-        undo()'s restore path. Asserts None rather than the original created
-        value: ObjectChange.diff_exclude_fields() (core, pre-existing) strips
-        created/last_updated from prechange_data_clean before undo() ever sees
-        it, so the original timestamp isn't recoverable here regardless -- what
-        this guards is that a real save() doesn't inject a wrong one instead."""
+        undo()'s restore path: a real save() re-triggers auto_now_add, which
+        would stamp `created` with revert time instead of the object's actual
+        original creation time. The deserialized instance never has `created`
+        set in the first place -- diff_exclude_fields() strips it from
+        prechange_data_clean -- so the fix sources it from the un-cleaned
+        prechange_data instead, which still has it."""
         import time
 
         request = RequestFactory().get(reverse('home'))
@@ -1115,6 +1116,7 @@ class BaseMergeTests:
         with event_tracking(request):
             site = Site.objects.create(name='Site 1', slug='site-1')
         site_id = site.id
+        original_created = site.created
 
         branch = self._create_and_provision_branch()
 
@@ -1128,7 +1130,54 @@ class BaseMergeTests:
         branch.revert(user=self.user, commit=True)
 
         site = Site.objects.get(id=site_id)
-        self.assertIsNone(site.created)
+        self.assertLess(abs((site.created - original_created).total_seconds()), 0.01)
+
+    def test_merge_cable_created_in_branch_has_terminations(self):
+        """
+        Cable.deserialize_object() (core) is a case flagged in review: it exists
+        for reasons unrelated to this PR's fix (popping a_terminations/
+        b_terminations before deserializing) and returns a plain
+        DeserializedObject, not a self-managing wrapper like
+        netbox_custom_objects' -- so hasattr(model, 'deserialize_object') alone
+        can't distinguish it from that case, which is why the dispatch keys off
+        hasattr(instance, 'm2m_data') instead (see the comment in apply()).
+
+        CableTermination/CablePath creation don't depend on Cable.save() firing
+        correctly during replay either way, since those are independently
+        change-tracked via their own ObjectChange records from the original
+        branch-side save() -- this doesn't regress either way -- but the
+        dispatch fix is still the right one on its own terms.
+        """
+        site = Site.objects.create(name='Cable Site', slug='cable-site')
+        device_a = Device.objects.create(
+            name='Cable Device A', site=site, device_type=self.device_type, role=self.device_role,
+        )
+        device_b = Device.objects.create(
+            name='Cable Device B', site=site, device_type=self.device_type, role=self.device_role,
+        )
+        interface_a = Interface.objects.create(device=device_a, name='eth0', type='1000base-t')
+        interface_b = Interface.objects.create(device=device_b, name='eth0', type='1000base-t')
+        interface_a_id, interface_b_id = interface_a.id, interface_b.id
+
+        branch = self._create_and_provision_branch()
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with activate_branch(branch), event_tracking(request):
+            cable = Cable(
+                a_terminations=[Interface.objects.get(id=interface_a_id)],
+                b_terminations=[Interface.objects.get(id=interface_b_id)],
+            )
+            cable.save()
+            cable_id = cable.id
+
+        branch.merge(user=self.user, commit=True)
+
+        self.assertTrue(Cable.objects.filter(id=cable_id).exists())
+        self.assertEqual(Interface.objects.get(id=interface_a_id).cable_id, cable_id)
+        self.assertEqual(Interface.objects.get(id=interface_b_id).cable_id, cable_id)
 
     def test_merge_apply_create_calls_model_save_not_raw_save_base(self):
         """

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1045,15 +1045,12 @@ class BaseMergeTests:
 
     def test_revert_restore_calls_model_save_not_raw_save_base(self):
         """
-        Restoring a deleted non-MPTT object during revert() must go through the
-        object's own save() method -- not DeserializedObject.save(), which calls
-        Model.save_base(..., raw=True) directly, bypassing any model-defined
-        save() override and auto_now/auto_now_add population. Neither is exercised
-        by NetBox core's own Site model, so this spies on Site.save() directly
-        rather than relying on an observable side effect; the more concrete,
-        production-shaped regression (an excluded auto_now field causing a NOT
-        NULL violation, and a save() override that applies schema DDL) is covered
-        in netbox_custom_objects' own test suite, which depends on this fix.
+        Restoring a deleted object during revert() must call the object's own
+        save(), not bypass it via DeserializedObject.save(). Site has no
+        auto_now/save()-override side effect to observe, so this spies on
+        Site.save() directly; the production-shaped regression (an excluded
+        auto_now field, a save() override applying schema DDL) is covered in
+        netbox_custom_objects' own test suite.
         """
         request = RequestFactory().get(reverse('home'))
         request.id = uuid.uuid4()


### PR DESCRIPTION
### Fixes: #650

## Summary

#620 changed the non-MPTT delete-restore path in `ObjectChange.undo()` from `instance.save(using=using)` to `deserialized.save(using=using)`. But `DeserializedObject.save()` calls `Model.save_base(..., raw=True)` directly, which Django's own source comments say outright: *"Call save on the Model baseclass directly. This bypasses any model-defined save."* It also skips `auto_now`/`auto_now_add` population, since that's normally applied by `Field.pre_save()` during a non-raw save.

This breaks two things for any model relying on either behavior:

- A model can exclude an `auto_now` field from `serialize_object()` to keep it out of change-log diffs -- NetBox core does exactly this for `ConfigContext`'s cache fields -- and rely on `save()` to repopulate it on any real save. A raw `save_base()` leaves it as whatever the deserializer defaulted it to (typically `None` for a field missing from the serialized payload), which raises a NOT NULL violation if the column requires one.
- A model's `save()` override can perform side effects a restore still needs to run. `netbox_custom_objects.CustomObjectTypeField.save()` applies the schema DDL that (re)creates a field's physical column on creation -- a raw `save_base()` silently skips it, so reverting a field deletion restores the field's own DB row but not its actual table column.

This was originally surfaced and root-caused against [netboxlabs/netbox-custom-objects#689](https://github.com/netboxlabs/netbox-custom-objects/issues/689) (two tests failing against v1.2.0, both passing on v1.1.2 with no other changes), filed here as #650.

## Fix

Restores `instance.save(using=using)` -- the real model `.save()`, not the wrapper's raw one -- and reapplies `deserialized.m2m_data` afterward, the same pattern the MPTT branch immediately above it already uses. This keeps the M2M-preservation `#620` was after without bypassing `auto_now` population or `save()` overrides.

**Scoped down per review** to `undo()` only. Both of #689's failing tests are on `undo()`'s DELETE-restore path (reverting a deleted COT / field), and #620 -- the change that broke them -- only ever touched `undo()`. An earlier revision of this PR also modified `apply()`'s CREATE path, following a speculative finding from an automated review pass claiming the same raw-save hazard existed there. That finding doesn't hold up: `apply()`'s CREATE path was never touched by #620, isn't implicated by either of #689's failing tests, and `DeserializedObject.save()` already reapplies M2M data internally via its own `set_base()` call, so the "M2M loss" concern for `apply()` specifically doesn't actually apply. `apply()` is now byte-for-byte unchanged from `main`.

I empirically checked whether reverting `apply()` reintroduces an LTree-specific issue (the recalled original motivation for #620's raw-save switch) by running the full `netbox_branching` suite: it didn't surface one. That's not proof no such issue exists outside current test coverage, but nothing regressed.

## Testing

Three regression tests, all scoped to `undo()`'s restore path (`BaseMergeTests`, shared by both merge strategies):

- `test_merge_revert_restores_deleted_non_mptt_object` -- a non-MPTT delete+revert round trip restores the object with its M2M data (tags) intact. Note: this passes even against `main`'s original code, since `DeserializedObject.save()` already preserves M2M via its own internal mechanism -- it's general revert-with-tags coverage, not a regression guard for M2M loss specifically.
- `test_revert_restore_calls_model_save_not_raw_save_base` -- spies on `Site.save` to confirm restore actually calls the model's own `save()` method rather than bypassing it via raw `save_base()`.
- `test_revert_restore_recovers_original_created_timestamp` -- a revert-restored object's `created` recovers the true original value, sourced from the raw (un-cleaned) `prechange_data` payload rather than the already-`diff_exclude_fields()`-stripped deserialized instance.

The more production-shaped regression this fixes -- an excluded `auto_now` field causing a NOT NULL violation, and a `save()` override applying schema DDL -- doesn't have an analogous fixture within this repo's own core-model test data, so it's exercised by `netbox_custom_objects`'s own test suite instead.

Verified:
- The spy test and the timestamp test both fail against `main`'s original code and pass with this fix. The M2M test passes both before and after, for the reason noted above.
- Full `netbox_branching` suite: 408 tests, 0 new failures (1 pre-existing PostgreSQL-version-specific error in `test_upgrade_from_v4_4_10`, 1 pre-existing query-count baseline drift in `test_list_objects_with_permission` -- both confirmed to fail identically without this change).
- Full `netbox_custom_objects.tests.test_branching` suite (the one that surfaced #689): 61 tests, 0 failures.