### PR TITLE
611 - add regression tests for front/rear port mappings merge/sync

### DIFF
--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1326,12 +1326,16 @@ class BaseMergeTests:
 
         # In branch: map the existing front port to the existing rear port
         with activate_branch(branch), event_tracking(request):
-            PortMapping.objects.create(
+            mapping = PortMapping.objects.create(
                 front_port=FrontPort.objects.get(id=front_port_id),
                 rear_port=RearPort.objects.get(id=rear_port_id),
                 front_port_position=3,
                 rear_port_position=4,
             )
+            mapping_id = mapping.id
+
+        # The mapping must be change-logged for the merge to be able to replay it
+        self._assert_object_changes(branch, PortMapping, mapping_id, 1, ['create'])
 
         # Main is still unmapped prior to the merge
         self.assertEqual(PortMapping.objects.filter(front_port_id=front_port_id).count(), 0)
@@ -1355,13 +1359,14 @@ class BaseMergeTests:
             role=self.device_role,
         )
         front_port, rear_port = self._create_ports(device)
-        PortMapping.objects.create(
+        mapping = PortMapping.objects.create(
             front_port=front_port,
             rear_port=rear_port,
             front_port_position=1,
             rear_port_position=1,
         )
         front_port_id = front_port.id
+        mapping_id = mapping.id
 
         branch = self._create_and_provision_branch()
 
@@ -1372,6 +1377,9 @@ class BaseMergeTests:
         # In branch: remove the mapping
         with activate_branch(branch), event_tracking(request):
             PortMapping.objects.get(front_port_id=front_port_id).delete()
+
+        # The deletion must be change-logged for the merge to be able to replay it
+        self._assert_object_changes(branch, PortMapping, mapping_id, 1, ['delete'])
 
         # Main still has the mapping prior to the merge
         self.assertEqual(PortMapping.objects.filter(front_port_id=front_port_id).count(), 1)

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1239,13 +1239,13 @@ class BaseMergeTests:
         # A successful cable connection creates two CablePath records (one per endpoint)
         self.assertEqual(CablePath.objects.count(), 2, 'Cable paths not populated after merge')
 
-    def _create_ports(self, device, suffix=''):
+    def _create_ports(self, device):
         """Helper to create a front/rear port pair on a device, with no mapping between them."""
         rear_port = RearPort.objects.create(
-            device=device, name=f'rear{suffix}', type='8p8c', positions=4
+            device=device, name='rear', type='8p8c', positions=4
         )
         front_port = FrontPort.objects.create(
-            device=device, name=f'front{suffix}', type='8p8c', positions=4
+            device=device, name='front', type='8p8c', positions=4
         )
         return front_port, rear_port
 
@@ -1288,6 +1288,9 @@ class BaseMergeTests:
 
         # The mapping must be change-logged for the merge to be able to replay it
         self._assert_object_changes(branch, PortMapping, mapping_id, 1, ['create'])
+
+        # Main is still unmapped prior to the merge
+        self.assertEqual(PortMapping.objects.filter(front_port_id=front_port_id).count(), 0)
 
         branch.merge(user=self.user, commit=True)
 

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -10,10 +10,13 @@ from dcim.models import (
     Device,
     DeviceRole,
     DeviceType,
+    FrontPort,
     Interface,
     Manufacturer,
     ModuleBay,
     ModuleBayTemplate,
+    PortMapping,
+    RearPort,
     Region,
     Site,
     VirtualChassis,
@@ -1235,6 +1238,150 @@ class BaseMergeTests:
         # Verify cable paths were recalculated — not left empty after merge (#150 regression)
         # A successful cable connection creates two CablePath records (one per endpoint)
         self.assertEqual(CablePath.objects.count(), 2, 'Cable paths not populated after merge')
+
+    def _create_ports(self, device, suffix=''):
+        """Helper to create a front/rear port pair on a device, with no mapping between them."""
+        rear_port = RearPort.objects.create(
+            device=device, name=f'rear{suffix}', type='8p8c', positions=4
+        )
+        front_port = FrontPort.objects.create(
+            device=device, name=f'front{suffix}', type='8p8c', positions=4
+        )
+        return front_port, rear_port
+
+    def test_merge_front_rear_port_mapping(self):
+        """
+        Test that a front/rear port mapping created in a branch survives the merge.
+
+        The association lives in the dcim.PortMapping junction model, which only became
+        change-logged in NetBox 4.6.6. Before that it emitted no ObjectChange and merge —
+        which replays ObjectChange records only — silently dropped the mapping.
+        Refs: #611
+        """
+        site = Site.objects.create(name='Test Site', slug='test-site')
+        device = Device.objects.create(
+            name='Device A',
+            site=site,
+            device_type=self.device_type,
+            role=self.device_role,
+        )
+        device_id = device.id
+
+        branch = self._create_and_provision_branch()
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In branch: create both ports and the mapping between them
+        with activate_branch(branch), event_tracking(request):
+            front_port, rear_port = self._create_ports(Device.objects.get(id=device_id))
+            mapping = PortMapping.objects.create(
+                front_port=front_port,
+                rear_port=rear_port,
+                front_port_position=1,
+                rear_port_position=2,
+            )
+            front_port_id = front_port.id
+            rear_port_id = rear_port.id
+            mapping_id = mapping.id
+
+        # The mapping must be change-logged for the merge to be able to replay it
+        self._assert_object_changes(branch, PortMapping, mapping_id, 1, ['create'])
+
+        branch.merge(user=self.user, commit=True)
+
+        # Ports and the mapping between them must all land in main
+        self.assertTrue(FrontPort.objects.filter(id=front_port_id).exists())
+        self.assertTrue(RearPort.objects.filter(id=rear_port_id).exists())
+        mappings = PortMapping.objects.filter(front_port_id=front_port_id)
+        self.assertEqual(mappings.count(), 1, 'Front/rear port mapping was dropped on merge (#611)')
+        merged_mapping = mappings.first()
+        self.assertEqual(merged_mapping.rear_port_id, rear_port_id)
+        self.assertEqual(merged_mapping.front_port_position, 1)
+        self.assertEqual(merged_mapping.rear_port_position, 2)
+
+    def test_merge_port_mapping_on_existing_ports(self):
+        """
+        Test merging a mapping added in a branch between ports which already exist in main.
+        Only the PortMapping row is new, so the merge has nothing else to carry it along with.
+        Refs: #611
+        """
+        site = Site.objects.create(name='Test Site', slug='test-site')
+        device = Device.objects.create(
+            name='Device A',
+            site=site,
+            device_type=self.device_type,
+            role=self.device_role,
+        )
+        front_port, rear_port = self._create_ports(device)
+        front_port_id = front_port.id
+        rear_port_id = rear_port.id
+
+        branch = self._create_and_provision_branch()
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In branch: map the existing front port to the existing rear port
+        with activate_branch(branch), event_tracking(request):
+            PortMapping.objects.create(
+                front_port=FrontPort.objects.get(id=front_port_id),
+                rear_port=RearPort.objects.get(id=rear_port_id),
+                front_port_position=3,
+                rear_port_position=4,
+            )
+
+        # Main is still unmapped prior to the merge
+        self.assertEqual(PortMapping.objects.filter(front_port_id=front_port_id).count(), 0)
+
+        branch.merge(user=self.user, commit=True)
+
+        mappings = PortMapping.objects.filter(front_port_id=front_port_id)
+        self.assertEqual(mappings.count(), 1, 'Port mapping added in branch was dropped on merge (#611)')
+        self.assertEqual(mappings.first().rear_port_position, 4)
+
+    def test_merge_port_mapping_deletion(self):
+        """
+        Test that deleting a front/rear port mapping in a branch removes it from main on merge.
+        Refs: #611
+        """
+        site = Site.objects.create(name='Test Site', slug='test-site')
+        device = Device.objects.create(
+            name='Device A',
+            site=site,
+            device_type=self.device_type,
+            role=self.device_role,
+        )
+        front_port, rear_port = self._create_ports(device)
+        PortMapping.objects.create(
+            front_port=front_port,
+            rear_port=rear_port,
+            front_port_position=1,
+            rear_port_position=1,
+        )
+        front_port_id = front_port.id
+
+        branch = self._create_and_provision_branch()
+
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # In branch: remove the mapping
+        with activate_branch(branch), event_tracking(request):
+            PortMapping.objects.get(front_port_id=front_port_id).delete()
+
+        # Main still has the mapping prior to the merge
+        self.assertEqual(PortMapping.objects.filter(front_port_id=front_port_id).count(), 1)
+
+        branch.merge(user=self.user, commit=True)
+
+        self.assertEqual(
+            PortMapping.objects.filter(front_port_id=front_port_id).count(), 0,
+            'Port mapping deleted in branch was not removed from main on merge (#611)'
+        )
 
     def test_merge_delete_after_main_delete(self):
         """

--- a/netbox_branching/tests/test_sync.py
+++ b/netbox_branching/tests/test_sync.py
@@ -18,9 +18,12 @@ from dcim.models import (
     Device,
     DeviceRole,
     DeviceType,
+    FrontPort,
     Interface,
     Manufacturer,
     Platform,
+    PortMapping,
+    RearPort,
     Region,
     Site,
     VirtualChassis,
@@ -1103,6 +1106,59 @@ class SyncTestCase(TransactionTestCase):
 
         branch.refresh_from_db()
         self.assertGreater(branch.last_sync, initial_last_sync)
+
+    # -------------------------------------------------------------------------
+    # Front/rear port mapping scenario
+    # -------------------------------------------------------------------------
+
+    def test_sync_front_rear_port_mapping_from_main(self):
+        """
+        Test that a front/rear port mapping created in main after provisioning is pulled
+        into the branch on sync.
+
+        The association lives in the dcim.PortMapping junction model, which only became
+        change-logged in NetBox 4.6.6. Before that it emitted no ObjectChange, so sync —
+        which replays ObjectChange records only — never saw it. Being listed in
+        INCLUDE_MODELS replicates the table at provisioning time, which does not help for
+        rows created afterwards.
+        Refs: #611
+        """
+        site = Site.objects.create(name='Test Site', slug='test-site')
+        device = Device.objects.create(
+            name='Device A',
+            site=site,
+            device_type=self.device_type,
+            role=self.device_role,
+        )
+
+        branch = self._create_and_provision_branch()
+
+        # In main, after provisioning: create a front/rear port pair and map them
+        with event_tracking(self.request):
+            rear_port = RearPort.objects.create(device=device, name='rear', type='8p8c', positions=4)
+            front_port = FrontPort.objects.create(device=device, name='front', type='8p8c', positions=4)
+            PortMapping.objects.create(
+                front_port=front_port,
+                rear_port=rear_port,
+                front_port_position=2,
+                rear_port_position=3,
+            )
+            front_port_id = front_port.id
+            rear_port_id = rear_port.id
+
+        # The branch has not seen any of this yet
+        with activate_branch(branch):
+            self.assertEqual(PortMapping.objects.filter(front_port_id=front_port_id).count(), 0)
+
+        branch.sync(user=self.user, commit=True)
+
+        with activate_branch(branch):
+            self.assertTrue(FrontPort.objects.filter(id=front_port_id).exists())
+            mappings = PortMapping.objects.filter(front_port_id=front_port_id)
+            self.assertEqual(mappings.count(), 1, 'Port mapping created in main was not synced into branch (#611)')
+            synced_mapping = mappings.first()
+            self.assertEqual(synced_mapping.rear_port_id, rear_port_id)
+            self.assertEqual(synced_mapping.rear_port_position, 3)
 
     # -------------------------------------------------------------------------
     # Double-delete scenario


### PR DESCRIPTION
### Fixes: #611 

The issue for #611 was actually fixed in NetBox, but this adds regression tests in branching to catch any regressions in the future.