### PR TITLE
Fix #632 - Distinguish merge collisions with main from invalid branch values

### DIFF
--- a/docs/using-branches/syncing-merging.md
+++ b/docs/using-branches/syncing-merging.md
@@ -122,16 +122,14 @@ Alternatively, if the conflicting changes are problematic, you can go back and m
 
 ### Collisions With Objects in Main
 
-Conflicts are detected by comparing the *same* object in your branch and in main, so a collision between two *different* objects cannot be flagged in advance. The common example is a shared resource: you place a device in rack unit 12 inside your branch, and meanwhile someone places a different device in that same slot in main. Each write is perfectly valid in its own schema, nothing is flagged as a conflict, and the collision only surfaces when the merge replays your change against main.
+Conflicts are detected by comparing the same object in your branch and in main, so a collision between two *different* objects cannot be flagged in advance — for example, a device you place in rack unit 12 in your branch and a different device someone places in that slot in main. Both writes are valid in their own schema; the collision surfaces only when the merge replays your change against main.
 
-When this happens, the merge fails and the job report describes it as a collision with the main schema, naming the underlying validation error (for example, "U12 is already occupied…"). This is worth distinguishing from an ordinary validation error, because the object you are colliding with is not in your branch at all — it is not visible there and no edit you make inside the branch will make it go away. There are two ways forward:
+The job report identifies these as a collision with the main schema and quotes the underlying error ("U12 is already occupied…"). Two ways forward:
 
-- Resolve the collision in main: move or delete whatever already claims the resource, then retry the merge. Choose this when you want to keep your branch's change as it stands, and note that it works under either merge strategy.
-- Change the value in your branch so that it no longer collides — assign the device to a different rack unit, say — and then merge using the **squash** strategy.
+- Resolve it in main: move or delete whatever already claims the resource, then retry. Works under either strategy.
+- Change the value in your branch, then merge using **squash**.
 
-That second remedy requires squash. Editing the object in your branch records a *new* change on top of the original one; the iterative strategy replays every recorded change in order, so it re-applies the original colliding value long before it reaches the change that fixed it, and fails on the same collision. The intermediate state cannot be written to main in any case — a contested rack unit is guarded by a database constraint as well as by validation. Squash collapses the object's changes into its final state, so the colliding value is never applied at all. This is the same recovery pattern as [Recovering from Duplicate Object Conflicts](#recovering-from-duplicate-object-conflicts) above.
-
-Note that squash does *not* help with a collision you have not resolved: with the branch left as it is, both strategies apply the same colliding value and fail identically.
+The second requires squash because iterative replays your original colliding value before reaching the change that fixed it. Squash does not help with a collision you have not resolved — both strategies then apply the same value and fail. Same recovery pattern as [Recovering from Duplicate Object Conflicts](#recovering-from-duplicate-object-conflicts).
 
 ## Dry Runs
 

--- a/docs/using-branches/syncing-merging.md
+++ b/docs/using-branches/syncing-merging.md
@@ -120,6 +120,19 @@ The good news is that you will be able to proceed with synchronizing or merging 
 
 Alternatively, if the conflicting changes are problematic, you can go back and make the necessary changes in main to avoid overwriting data within your branch.
 
+### Collisions With Objects in Main
+
+Conflicts are detected by comparing the *same* object in your branch and in main, so a collision between two *different* objects cannot be flagged in advance. The common example is a shared resource: you place a device in rack unit 12 inside your branch, and meanwhile someone places a different device in that same slot in main. Each write is perfectly valid in its own schema, nothing is flagged as a conflict, and the collision only surfaces when the merge replays your change against main.
+
+When this happens, the merge fails and the job report describes it as a collision with the main schema, naming the underlying validation error (for example, "U12 is already occupied…"). This is worth distinguishing from an ordinary validation error, because the object you are colliding with is not in your branch at all — it is not visible there and no edit you make inside the branch will make it go away. There are two ways forward:
+
+- Resolve the collision in main: move or delete whatever already claims the resource, then retry the merge. Choose this when you want to keep your branch's change as it stands, and note that it works under either merge strategy.
+- Change the value in your branch so that it no longer collides — assign the device to a different rack unit, say — and then merge using the **squash** strategy.
+
+That second remedy requires squash. Editing the object in your branch records a *new* change on top of the original one; the iterative strategy replays every recorded change in order, so it re-applies the original colliding value long before it reaches the change that fixed it, and fails on the same collision. The intermediate state cannot be written to main in any case — a contested rack unit is guarded by a database constraint as well as by validation. Squash collapses the object's changes into its final state, so the colliding value is never applied at all. This is the same recovery pattern as [Recovering from Duplicate Object Conflicts](#recovering-from-duplicate-object-conflicts) above.
+
+Note that squash does *not* help with a collision you have not resolved: with the branch left as it is, both strategies apply the same colliding value and fail identically.
+
 ## Dry Runs
 
 By default, NetBox will perform a "dry run" when synchronizing or merging a branch through the web UI. This means that it will replicate all the relevant changes to check for errors before ultimately aborting the operation and returning the branch to its original state. To permanently apply the changes instead, check the **Commit changes** checkbox before submitting the form.

--- a/netbox_branching/error_report.py
+++ b/netbox_branching/error_report.py
@@ -87,14 +87,18 @@ def annotate_validation_error(exc, model_class, object_id, content_type_id, bran
 
 def _classify_validation_error(exc):
     """
-    Return an ``(is_uniqueness, first_field)`` tuple for a ValidationError. ``first_field``
-    is None for an error that carries no field mapping at all.
+    Return an ``(is_uniqueness, first_field)`` tuple for a ValidationError. ``first_field`` is
+    None for an error that names no field -- including one keyed on Django's NON_FIELD_ERRORS
+    sentinel, which must never reach the report as if it were a field.
     """
+    def named(field):
+        return None if field == NON_FIELD_ERRORS else field
+
     if hasattr(exc, 'error_dict'):
         for field, field_errors in exc.error_dict.items():
             if any(e.code in ('unique', 'unique_together') for e in field_errors):
-                return True, field
-        return False, next(iter(exc.error_dict), None)
+                return True, named(field)
+        return False, named(next(iter(exc.error_dict), None))
     if hasattr(exc, 'error_list') and exc.error_list:
         return any(e.code in ('unique', 'unique_together') for e in exc.error_list), None
     return False, None
@@ -113,9 +117,13 @@ def _first_error_message(exc, field):
 
 def _probe_branch(model_class, object_id, branch, field):
     """
-    Re-validate the object inside its own branch schema. Returns ``(does field fail there,
-    its current value in the branch)``, or None if the probe could not run -- which callers
-    must treat as unknown, never as clean.
+    Re-validate the object inside its own branch schema. Returns ``(is it invalid there, the
+    current value of field in the branch)``, or None if the probe could not run -- which
+    callers must treat as unknown, never as clean.
+
+    Any failure counts, not just one on ``field``: clean() raises on the first problem it
+    finds, so an unrelated error in the branch says nothing about whether the check that
+    blocked the merge would have failed there too.
     """
     logger = logging.getLogger('netbox_branching.error_report')
     try:
@@ -123,12 +131,12 @@ def _probe_branch(model_class, object_id, branch, field):
             instance = model_class.objects.using(branch.connection_name).get(pk=object_id)
             try:
                 full_clean_with_file_check(instance, logger)
-            except ValidationError as e:
-                failing = set(e.error_dict) if hasattr(e, 'error_dict') else {NON_FIELD_ERRORS}
+            except ValidationError:
+                invalid = True
             else:
-                failing = set()
+                invalid = False
             value = getattr(instance, field, None) if field else None
-            return field in failing, str(value) if value is not None else None
+            return invalid, str(value) if value is not None else None
     # Blind by design: a failing probe must never displace the real ValidationError.
     except Exception as e:  # noqa: BLE001
         logger.debug(f'Branch validity probe failed for {model_class.__name__} {object_id}: {e}')
@@ -143,8 +151,7 @@ def _flag_main_collision(exc, model_class, object_id, branch):
     is_uniqueness, field = _classify_validation_error(exc)
     if is_uniqueness or object_id is None:
         return
-    probe_field = field or NON_FIELD_ERRORS
-    if (result := _probe_branch(model_class, object_id, branch, probe_field)) is None:
+    if (result := _probe_branch(model_class, object_id, branch, field)) is None:
         return
     fails_in_branch, value = result
     if fails_in_branch:

--- a/netbox_branching/error_report.py
+++ b/netbox_branching/error_report.py
@@ -1,13 +1,15 @@
+import logging
 import re
 
 from django.apps import apps
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.db import IntegrityError
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _l
 
 from .choices import BranchMergeStrategyChoices
 from .constants import PG_UNIQUE_VIOLATION
+from .utilities import activate_branch, full_clean_with_file_check
 
 # Recommendation message templates — separated from decision logic in get_merge_recommendations()
 _REC_RENAME_WITH_FIELD = _l(
@@ -27,6 +29,34 @@ _REC_FIX_FIELD = _l(
 _REC_FIX_GENERIC = _l(
     'Fix the invalid value on the affected object in the branch before retrying.'
 )
+_REC_COLLISION_FIX_MAIN_WITH_FIELD = _l(
+    'Resolve the collision in the main schema. Whatever the change collides with on "%(field)s" exists only'
+    ' in main, so it is neither visible nor editable from within the branch; move or delete it, then retry'
+    ' the merge. The error above names what it claims.'
+)
+_REC_COLLISION_FIX_MAIN = _l(
+    'Resolve the collision in the main schema. The conflicting object exists only in main, so it is neither'
+    ' visible nor editable from within the branch; move or delete it, then retry the merge.'
+)
+_REC_COLLISION_FIX_BRANCH_WITH_FIELD = _l(
+    'Change "%(field)s" on the affected object in the branch to a value that does not collide with the'
+    ' main schema, then retry the merge.'
+)
+_REC_COLLISION_FIX_BRANCH = _l(
+    'Change the affected object in the branch so that it no longer collides with the main schema, then'
+    ' retry the merge.'
+)
+_REC_COLLISION_FIX_BRANCH_THEN_SQUASH_WITH_FIELD = _l(
+    'Change "%(field)s" on the affected object in the branch, then merge using the Squash strategy. The'
+    ' Iterative strategy replays every recorded change in order, so it will apply the original value again'
+    ' and fail on the same collision; Squash applies only the final state of each object.'
+)
+_REC_COLLISION_FIX_BRANCH_THEN_SQUASH = _l(
+    'Change the affected object in the branch so that it no longer collides with the main schema, then merge'
+    ' using the Squash strategy. The Iterative strategy replays every recorded change in order, so it will'
+    ' apply the original value again and fail on the same collision; Squash applies only the final state of'
+    ' each object.'
+)
 _REC_REVIEW_LOG = _l('Review the job log for full error details.')
 _REC_TRY_SQUASH_DB = _l(
     'Switch to the Squash merge strategy, which may resolve some database-level conflicts.'
@@ -40,11 +70,100 @@ __all__ = (
 )
 
 
-def annotate_validation_error(exc, model_class, object_id, content_type_id):
-    """Attach branch operation context to a ValidationError before re-raising."""
+def annotate_validation_error(exc, model_class, object_id, content_type_id, branch=None):
+    """
+    Attach branch operation context to a ValidationError before re-raising.
+
+    When ``branch`` is given, the object is additionally re-validated inside its own
+    branch schema to work out *where* the offending value is actually invalid. A
+    failure that does not reproduce there is not a bad value in the branch at all: it
+    is a collision with an object that exists only in main -- two devices independently
+    claiming the same rack unit, say -- which nothing the user does to that field inside
+    the branch necessarily resolves. Recording that distinction here is what lets the
+    job report name the real problem instead of advising the user to "fix" a value that
+    is perfectly valid where it lives. (#632)
+    """
     exc.netbox_branching_model = model_class
     exc.netbox_branching_object_id = object_id
     exc.netbox_branching_content_type_id = content_type_id
+    if branch is not None:
+        _flag_main_collision(exc, model_class, object_id, branch)
+
+
+def _classify_validation_error(exc):
+    """
+    Return an ``(is_uniqueness, first_field)`` tuple for a ValidationError. ``first_field``
+    is None for an error that carries no field mapping at all.
+    """
+    if hasattr(exc, 'error_dict'):
+        for field, field_errors in exc.error_dict.items():
+            if any(e.code in ('unique', 'unique_together') for e in field_errors):
+                return True, field
+        return False, next(iter(exc.error_dict), None)
+    if hasattr(exc, 'error_list') and exc.error_list:
+        return any(e.code in ('unique', 'unique_together') for e in exc.error_list), None
+    return False, None
+
+
+def _first_error_message(exc, field):
+    """Return the underlying validation message for ``field``, for display in the report."""
+    if hasattr(exc, 'error_dict'):
+        errors = exc.error_dict.get(field) or next(iter(exc.error_dict.values()), None)
+    else:
+        errors = getattr(exc, 'error_list', None)
+    if errors:
+        return ' '.join(errors[0].messages)
+    return None
+
+
+def _probe_branch(model_class, object_id, branch, field):
+    """
+    Re-validate the object as it exists inside its own branch schema.
+
+    Returns a ``(fails_in_branch, value)`` tuple: whether ``field`` is among the fields
+    that fail validation *there*, and that field's current value in the branch. Returns
+    None if the probe could not be run at all -- the object is gone, the connection is
+    unusable, the model does something unexpected during validation. Callers must read
+    None as "unknown" and fall back, never as "clean": this runs while an operation is
+    already failing, and a probe that cannot answer must not be allowed to invent one.
+    """
+    logger = logging.getLogger('netbox_branching.error_report')
+    try:
+        with activate_branch(branch):
+            instance = model_class.objects.using(branch.connection_name).get(pk=object_id)
+            try:
+                full_clean_with_file_check(instance, logger)
+            except ValidationError as e:
+                failing = set(e.error_dict) if hasattr(e, 'error_dict') else {NON_FIELD_ERRORS}
+            else:
+                failing = set()
+            value = getattr(instance, field, None) if field else None
+            return field in failing, str(value) if value is not None else None
+    # Deliberately blind: this runs while a merge is already failing, and anything the probe
+    # raises must be swallowed rather than replace the user's real ValidationError with an
+    # unrelated traceback. Narrowing the list would only trade a missing hint for a crash.
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f'Branch validity probe failed for {model_class.__name__} {object_id}: {e}')
+        return None
+
+
+def _flag_main_collision(exc, model_class, object_id, branch):
+    """
+    Mark ``exc`` as a collision with main if the same object validates cleanly inside its
+    own branch. Uniqueness errors are left alone: their existing classification already
+    points the user at both schemas, so the probe would buy nothing and cost a query.
+    """
+    is_uniqueness, field = _classify_validation_error(exc)
+    if is_uniqueness or object_id is None:
+        return
+    probe_field = field or NON_FIELD_ERRORS
+    if (result := _probe_branch(model_class, object_id, branch, probe_field)) is None:
+        return
+    fails_in_branch, value = result
+    if fails_in_branch:
+        return
+    exc.netbox_branching_main_collision = True
+    exc.netbox_branching_value = value
 
 
 def _get_field_from_constraint(table_name, constraint_name):
@@ -97,6 +216,7 @@ def _analyze_integrity_error(exc, table_model_map):
             'model': table_model_map.get(table_name) if table_name else None,
             'field': field,
             'value': value,
+            'detail': None,
             'object_id': None,
             'content_type_id': None,
         }
@@ -106,6 +226,7 @@ def _analyze_integrity_error(exc, table_model_map):
         'model': None,
         'field': None,
         'value': None,
+        'detail': None,
         'object_id': None,
         'content_type_id': None,
     }
@@ -116,25 +237,23 @@ def _analyze_validation_error(exc):
     model_class = getattr(exc, 'netbox_branching_model', None)
     model_name = model_class._meta.verbose_name if model_class else None
 
-    is_uniqueness = False
-    first_field = None
+    is_uniqueness, first_field = _classify_validation_error(exc)
 
-    if hasattr(exc, 'error_dict'):
-        for field, field_errors in exc.error_dict.items():
-            if any(e.code in ('unique', 'unique_together') for e in field_errors):
-                is_uniqueness = True
-                first_field = field
-                break
-        if not is_uniqueness:
-            first_field = next(iter(exc.error_dict), None)
-    elif hasattr(exc, 'error_list') and exc.error_list:
-        is_uniqueness = any(e.code in ('unique', 'unique_together') for e in exc.error_list)
+    if is_uniqueness:
+        error_type = 'unique_constraint'
+    elif getattr(exc, 'netbox_branching_main_collision', False):
+        error_type = 'main_collision'
+    else:
+        error_type = 'validation_error'
 
     return {
-        'type': 'unique_constraint' if is_uniqueness else 'validation_error',
+        'type': error_type,
         'model': model_name,
         'field': first_field,
-        'value': None,
+        'value': getattr(exc, 'netbox_branching_value', None),
+        # The underlying message ("U12 is already occupied...") is the whole point of a
+        # collision entry: it names the resource that main has already claimed.
+        'detail': _first_error_message(exc, first_field) if error_type == 'main_collision' else None,
         'object_id': getattr(exc, 'netbox_branching_object_id', None),
         'content_type_id': getattr(exc, 'netbox_branching_content_type_id', None),
     }
@@ -143,7 +262,7 @@ def _analyze_validation_error(exc):
 def build_error_report(exc):
     """
     Analyze an exception and return a structured report entry dict containing:
-    type, model, field, value, object_id, content_type_id.
+    type, model, field, value, detail, object_id, content_type_id.
     """
     table_model_map = {model._meta.db_table: model._meta.verbose_name for model in apps.get_models()}
     if isinstance(exc, IntegrityError):
@@ -155,6 +274,7 @@ def build_error_report(exc):
         'model': None,
         'field': None,
         'value': None,
+        'detail': None,
         'object_id': None,
         'content_type_id': None,
     }
@@ -178,6 +298,19 @@ def get_entry_message(entry):
                 'base': ' '.join(parts),
             }
         return _('Unique constraint violation: an object already exists in the main schema.')
+
+    if error_type == 'main_collision':
+        parts = [p for p in [model_str, field_str] if p]
+        where = ' '.join(parts) if parts else _('the affected object')
+        if detail := entry.get('detail'):
+            return _('Collision with the main schema on %(where)s: %(detail)s') % {
+                'where': where,
+                'detail': detail,
+            }
+        return _(
+            'Collision with the main schema on %(where)s. The value is valid within the branch; the'
+            ' conflict is with an object that exists only in main.'
+        ) % {'where': where}
 
     if error_type == 'validation_error':
         parts = [p for p in [model_str, field_str] if p]
@@ -204,6 +337,28 @@ def get_merge_recommendations(entry, merge_strategy=None):
         if is_squash:
             return [rename_rec]
         return [rename_rec, _REC_TRY_SQUASH_UNIQUE]
+
+    if error_type == 'main_collision':
+        # Changing the value in the branch does not, on its own, let an iterative merge
+        # through: iterative replays the recorded changes in order, so it re-applies the
+        # original colliding value long before it reaches the change that fixed it. The
+        # collision is enforced by a database constraint as well as by clean(), so that
+        # intermediate state cannot be materialized in main at all -- only squash, which
+        # collapses an object's changes into its final state, avoids it. (#632)
+        # Deliberately not interpolating `value` here: it is the branch object's *current*
+        # value, which stops matching the contested resource as soon as the user applies the
+        # branch-side remedy below and retries (branch device moved to U21, main still holds
+        # U12). The message carries the real one.
+        if field:
+            fix_main = _REC_COLLISION_FIX_MAIN_WITH_FIELD % {'field': field}
+            branch_template = (
+                _REC_COLLISION_FIX_BRANCH_WITH_FIELD if is_squash else _REC_COLLISION_FIX_BRANCH_THEN_SQUASH_WITH_FIELD
+            )
+            fix_branch = branch_template % {'field': field}
+        else:
+            fix_main = _REC_COLLISION_FIX_MAIN
+            fix_branch = _REC_COLLISION_FIX_BRANCH if is_squash else _REC_COLLISION_FIX_BRANCH_THEN_SQUASH
+        return [fix_main, fix_branch]
 
     if error_type == 'validation_error':
         if field:

--- a/netbox_branching/error_report.py
+++ b/netbox_branching/error_report.py
@@ -74,14 +74,9 @@ def annotate_validation_error(exc, model_class, object_id, content_type_id, bran
     """
     Attach branch operation context to a ValidationError before re-raising.
 
-    When ``branch`` is given, the object is additionally re-validated inside its own
-    branch schema to work out *where* the offending value is actually invalid. A
-    failure that does not reproduce there is not a bad value in the branch at all: it
-    is a collision with an object that exists only in main -- two devices independently
-    claiming the same rack unit, say -- which nothing the user does to that field inside
-    the branch necessarily resolves. Recording that distinction here is what lets the
-    job report name the real problem instead of advising the user to "fix" a value that
-    is perfectly valid where it lives. (#632)
+    With ``branch``, also re-validate the object inside its own branch schema: a failure that
+    does not reproduce there is a collision with a main-only object, not a bad value in the
+    branch. (#632)
     """
     exc.netbox_branching_model = model_class
     exc.netbox_branching_object_id = object_id
@@ -118,14 +113,9 @@ def _first_error_message(exc, field):
 
 def _probe_branch(model_class, object_id, branch, field):
     """
-    Re-validate the object as it exists inside its own branch schema.
-
-    Returns a ``(fails_in_branch, value)`` tuple: whether ``field`` is among the fields
-    that fail validation *there*, and that field's current value in the branch. Returns
-    None if the probe could not be run at all -- the object is gone, the connection is
-    unusable, the model does something unexpected during validation. Callers must read
-    None as "unknown" and fall back, never as "clean": this runs while an operation is
-    already failing, and a probe that cannot answer must not be allowed to invent one.
+    Re-validate the object inside its own branch schema. Returns ``(does field fail there,
+    its current value in the branch)``, or None if the probe could not run -- which callers
+    must treat as unknown, never as clean.
     """
     logger = logging.getLogger('netbox_branching.error_report')
     try:
@@ -139,9 +129,7 @@ def _probe_branch(model_class, object_id, branch, field):
                 failing = set()
             value = getattr(instance, field, None) if field else None
             return field in failing, str(value) if value is not None else None
-    # Deliberately blind: this runs while a merge is already failing, and anything the probe
-    # raises must be swallowed rather than replace the user's real ValidationError with an
-    # unrelated traceback. Narrowing the list would only trade a missing hint for a crash.
+    # Blind by design: a failing probe must never displace the real ValidationError.
     except Exception as e:  # noqa: BLE001
         logger.debug(f'Branch validity probe failed for {model_class.__name__} {object_id}: {e}')
         return None
@@ -149,9 +137,8 @@ def _probe_branch(model_class, object_id, branch, field):
 
 def _flag_main_collision(exc, model_class, object_id, branch):
     """
-    Mark ``exc`` as a collision with main if the same object validates cleanly inside its
-    own branch. Uniqueness errors are left alone: their existing classification already
-    points the user at both schemas, so the probe would buy nothing and cost a query.
+    Mark ``exc`` as a collision with main if the object validates cleanly in its own branch.
+    Uniqueness errors are skipped; their existing classification already names both schemas.
     """
     is_uniqueness, field = _classify_validation_error(exc)
     if is_uniqueness or object_id is None:
@@ -251,8 +238,7 @@ def _analyze_validation_error(exc):
         'model': model_name,
         'field': first_field,
         'value': getattr(exc, 'netbox_branching_value', None),
-        # The underlying message ("U12 is already occupied...") is the whole point of a
-        # collision entry: it names the resource that main has already claimed.
+        # Names the resource main has already claimed
         'detail': _first_error_message(exc, first_field) if error_type == 'main_collision' else None,
         'object_id': getattr(exc, 'netbox_branching_object_id', None),
         'content_type_id': getattr(exc, 'netbox_branching_content_type_id', None),
@@ -339,16 +325,10 @@ def get_merge_recommendations(entry, merge_strategy=None):
         return [rename_rec, _REC_TRY_SQUASH_UNIQUE]
 
     if error_type == 'main_collision':
-        # Changing the value in the branch does not, on its own, let an iterative merge
-        # through: iterative replays the recorded changes in order, so it re-applies the
-        # original colliding value long before it reaches the change that fixed it. The
-        # collision is enforced by a database constraint as well as by clean(), so that
-        # intermediate state cannot be materialized in main at all -- only squash, which
-        # collapses an object's changes into its final state, avoids it. (#632)
-        # Deliberately not interpolating `value` here: it is the branch object's *current*
-        # value, which stops matching the contested resource as soon as the user applies the
-        # branch-side remedy below and retries (branch device moved to U21, main still holds
-        # U12). The message carries the real one.
+        # Iterative replays the original colliding value before reaching the change that
+        # fixed it, so the branch-side remedy only works under squash. (#632)
+        # Not interpolating `value`: it is the branch object's current value, which stops
+        # matching the contested resource once the branch-side remedy is applied.
         if field:
             fix_main = _REC_COLLISION_FIX_MAIN_WITH_FIELD % {'field': field}
             branch_template = (

--- a/netbox_branching/merge_strategies/iterative.py
+++ b/netbox_branching/merge_strategies/iterative.py
@@ -33,7 +33,10 @@ class IterativeMergeStrategy(MergeStrategy):
                 try:
                     change.apply(branch, using=DEFAULT_DB_ALIAS, logger=logger)
                 except ValidationError as e:
-                    annotate_validation_error(e, model_class, change.changed_object_id, change.changed_object_type_id)
+                    annotate_validation_error(
+                        e, model_class, change.changed_object_id, change.changed_object_type_id,
+                        branch=branch,
+                    )
                     raise
 
         self._clean(models)

--- a/netbox_branching/merge_strategies/squash.py
+++ b/netbox_branching/merge_strategies/squash.py
@@ -226,6 +226,7 @@ class SquashMergeStrategy(MergeStrategy):
                         e, model_class,
                         collapsed.last_change.changed_object_id,
                         collapsed.last_change.changed_object_type_id,
+                        branch=branch,
                     )
                     raise
 

--- a/netbox_branching/tests/test_error_report.py
+++ b/netbox_branching/tests/test_error_report.py
@@ -8,7 +8,7 @@ logic with no DB access, so the tests run as SimpleTestCase.
 from types import SimpleNamespace
 
 from dcim.models import Site
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.db import IntegrityError
 from django.test import SimpleTestCase
 
@@ -137,6 +137,28 @@ class MainCollisionClassificationTestCase(SimpleTestCase):
         """Uniqueness failures already point the user at both schemas."""
         exc = self._flagged(ValidationError({'name': [ValidationError('taken', code='unique')]}))
         self.assertEqual(build_error_report(exc)['type'], 'unique_constraint')
+
+    def test_non_field_error_does_not_surface_the_django_sentinel_as_a_field(self):
+        """
+        A clean() error keyed on NON_FIELD_ERRORS must not render as Device "__all__" in the
+        report or the recommendations.
+        """
+        exc = self._flagged(ValidationError({NON_FIELD_ERRORS: ['cross-field check failed']}))
+        entry = build_error_report(exc)
+        self.assertIsNone(entry['field'])
+        self.assertEqual(entry['detail'], 'cross-field check failed')
+        self.assertNotIn('__all__', get_entry_message(entry))
+        recs = get_merge_recommendations(entry, merge_strategy=BranchMergeStrategyChoices.ITERATIVE)
+        self.assertNotIn('__all__', ' '.join(str(r) for r in recs))
+
+    def test_unique_together_error_does_not_surface_the_django_sentinel_as_a_field(self):
+        """validate_unique() files unique_together failures under NON_FIELD_ERRORS."""
+        exc = ValidationError({NON_FIELD_ERRORS: [ValidationError('taken', code='unique_together')]})
+        annotate_validation_error(exc, Site, object_id=7, content_type_id=42)
+        entry = build_error_report(exc)
+        self.assertEqual(entry['type'], 'unique_constraint')
+        self.assertIsNone(entry['field'])
+        self.assertNotIn('__all__', get_entry_message(entry))
 
     def test_every_entry_type_carries_a_detail_key(self):
         """views.py splats the entry into the template context; the shape must be uniform."""

--- a/netbox_branching/tests/test_error_report.py
+++ b/netbox_branching/tests/test_error_report.py
@@ -107,9 +107,8 @@ class BuildErrorReportTestCase(SimpleTestCase):
 
 class MainCollisionClassificationTestCase(SimpleTestCase):
     """
-    A ValidationError flagged as a collision with main is classified apart from an
-    ordinary validation error, because the guidance the two need is opposite: one is
-    fixed inside the branch, the other cannot be. (#632)
+    A collision with main is classified apart from an ordinary validation error: one is fixed
+    inside the branch, the other cannot be. (#632)
     """
 
     def _flagged(self, exc, value='12.0'):
@@ -135,10 +134,7 @@ class MainCollisionClassificationTestCase(SimpleTestCase):
         self.assertIsNone(entry['value'])
 
     def test_uniqueness_error_is_never_reclassified(self):
-        """
-        Uniqueness failures already point the user at both schemas and benefit from the
-        squash suggestion, so the collision flag must not steal them.
-        """
+        """Uniqueness failures already point the user at both schemas."""
         exc = self._flagged(ValidationError({'name': [ValidationError('taken', code='unique')]}))
         self.assertEqual(build_error_report(exc)['type'], 'unique_constraint')
 
@@ -254,9 +250,8 @@ class GetMergeRecommendationsTestCase(SimpleTestCase):
 
     def test_main_collision_recommendations_never_quote_the_branch_side_value(self):
         """
-        `value` is the branch object's current value, which stops matching the contested
-        resource the moment the user applies the branch-side remedy and retries. Quoting it
-        in the main-side recommendation would then point at the wrong slot entirely.
+        `value` is the branch object's current value; once the branch-side remedy is applied
+        it no longer names the contested resource.
         """
         recs = get_merge_recommendations(
             {'type': 'main_collision', 'field': 'position', 'value': '21.0'},
@@ -266,9 +261,8 @@ class GetMergeRecommendationsTestCase(SimpleTestCase):
 
     def test_main_collision_under_iterative_routes_the_branch_side_fix_through_squash(self):
         """
-        Editing the value in the branch is not enough under iterative: it replays the
-        original colliding value before reaching the change that fixed it, so the retry
-        fails identically. The branch-side route has to name squash to be usable. (#632)
+        Under iterative the branch-side route has to name squash: the retry replays the
+        original colliding value and fails identically. (#632)
         """
         recs = get_merge_recommendations(
             {'type': 'main_collision', 'field': 'position', 'value': '12.0'},
@@ -277,7 +271,7 @@ class GetMergeRecommendationsTestCase(SimpleTestCase):
         branch_side = str(recs[1])
         self.assertIn('Squash', branch_side)
         self.assertIn('position', branch_side)
-        # The main-side route works under either strategy and needs no such caveat
+        # The main-side route works under either strategy
         self.assertNotIn('Squash', str(recs[0]))
 
     def test_main_collision_under_squash_omits_the_redundant_squash_suggestion(self):

--- a/netbox_branching/tests/test_error_report.py
+++ b/netbox_branching/tests/test_error_report.py
@@ -105,6 +105,55 @@ class BuildErrorReportTestCase(SimpleTestCase):
         self.assertEqual(entry['model'], 'site')
 
 
+class MainCollisionClassificationTestCase(SimpleTestCase):
+    """
+    A ValidationError flagged as a collision with main is classified apart from an
+    ordinary validation error, because the guidance the two need is opposite: one is
+    fixed inside the branch, the other cannot be. (#632)
+    """
+
+    def _flagged(self, exc, value='12.0'):
+        annotate_validation_error(exc, Site, object_id=7, content_type_id=42)
+        exc.netbox_branching_main_collision = True
+        exc.netbox_branching_value = value
+        return exc
+
+    def test_flagged_error_classified_as_main_collision(self):
+        exc = self._flagged(ValidationError({'position': ['U12 is already occupied']}))
+        entry = build_error_report(exc)
+        self.assertEqual(entry['type'], 'main_collision')
+        self.assertEqual(entry['field'], 'position')
+        self.assertEqual(entry['value'], '12.0')
+        self.assertEqual(entry['detail'], 'U12 is already occupied')
+
+    def test_unflagged_error_stays_a_validation_error_and_carries_no_detail(self):
+        exc = ValidationError({'position': ['U12 is already occupied']})
+        annotate_validation_error(exc, Site, object_id=7, content_type_id=42)
+        entry = build_error_report(exc)
+        self.assertEqual(entry['type'], 'validation_error')
+        self.assertIsNone(entry['detail'])
+        self.assertIsNone(entry['value'])
+
+    def test_uniqueness_error_is_never_reclassified(self):
+        """
+        Uniqueness failures already point the user at both schemas and benefit from the
+        squash suggestion, so the collision flag must not steal them.
+        """
+        exc = self._flagged(ValidationError({'name': [ValidationError('taken', code='unique')]}))
+        self.assertEqual(build_error_report(exc)['type'], 'unique_constraint')
+
+    def test_every_entry_type_carries_a_detail_key(self):
+        """views.py splats the entry into the template context; the shape must be uniform."""
+        entries = [
+            build_error_report(_make_integrity_error(sqlstate=PG_UNIQUE_VIOLATION, table_name='dcim_site')),
+            build_error_report(_make_integrity_error(sqlstate='42P01')),
+            build_error_report(ValidationError('boom')),
+            build_error_report(RuntimeError('boom')),
+        ]
+        for entry in entries:
+            self.assertIn('detail', entry)
+
+
 class GetEntryMessageTestCase(SimpleTestCase):
 
     def test_unique_constraint_with_full_context_includes_model_field_value(self):
@@ -127,6 +176,24 @@ class GetEntryMessageTestCase(SimpleTestCase):
         msg = get_entry_message({'type': 'validation_error', 'model': 'site', 'field': 'name'})
         self.assertIn('Site', msg)
         self.assertIn('name', msg)
+
+    def test_main_collision_message_names_main_and_quotes_the_underlying_error(self):
+        msg = get_entry_message({
+            'type': 'main_collision',
+            'model': 'device',
+            'field': 'position',
+            'value': '12.0',
+            'detail': 'U12 is already occupied',
+        })
+        self.assertIn('Device', msg)
+        self.assertIn('position', msg)
+        self.assertIn('main schema', msg)
+        self.assertIn('U12 is already occupied', msg)
+
+    def test_main_collision_message_without_detail_still_explains_where_the_conflict_is(self):
+        msg = get_entry_message({'type': 'main_collision', 'model': 'device', 'field': 'position'})
+        self.assertIn('main', msg)
+        self.assertIn('valid within the branch', msg)
 
     def test_database_error_returns_generic_message(self):
         msg = get_entry_message({'type': 'database_error'})
@@ -174,6 +241,65 @@ class GetMergeRecommendationsTestCase(SimpleTestCase):
         )
         self.assertEqual(len(recs), 1)
         self.assertIn('name', str(recs[0]))
+
+    def test_main_collision_offers_a_main_side_and_a_branch_side_route(self):
+        recs = get_merge_recommendations(
+            {'type': 'main_collision', 'field': 'position', 'value': '12.0'},
+            merge_strategy=BranchMergeStrategyChoices.ITERATIVE,
+        )
+        joined = ' '.join(str(r) for r in recs)
+        self.assertEqual(len(recs), 2)
+        self.assertIn('main schema', joined)
+        self.assertIn('position', joined)
+
+    def test_main_collision_recommendations_never_quote_the_branch_side_value(self):
+        """
+        `value` is the branch object's current value, which stops matching the contested
+        resource the moment the user applies the branch-side remedy and retries. Quoting it
+        in the main-side recommendation would then point at the wrong slot entirely.
+        """
+        recs = get_merge_recommendations(
+            {'type': 'main_collision', 'field': 'position', 'value': '21.0'},
+            merge_strategy=BranchMergeStrategyChoices.ITERATIVE,
+        )
+        self.assertNotIn('21.0', ' '.join(str(r) for r in recs))
+
+    def test_main_collision_under_iterative_routes_the_branch_side_fix_through_squash(self):
+        """
+        Editing the value in the branch is not enough under iterative: it replays the
+        original colliding value before reaching the change that fixed it, so the retry
+        fails identically. The branch-side route has to name squash to be usable. (#632)
+        """
+        recs = get_merge_recommendations(
+            {'type': 'main_collision', 'field': 'position', 'value': '12.0'},
+            merge_strategy=BranchMergeStrategyChoices.ITERATIVE,
+        )
+        branch_side = str(recs[1])
+        self.assertIn('Squash', branch_side)
+        self.assertIn('position', branch_side)
+        # The main-side route works under either strategy and needs no such caveat
+        self.assertNotIn('Squash', str(recs[0]))
+
+    def test_main_collision_under_squash_omits_the_redundant_squash_suggestion(self):
+        for entry in ({'type': 'main_collision', 'field': 'position', 'value': '12.0'},
+                      {'type': 'main_collision'}):
+            recs = get_merge_recommendations(entry, merge_strategy=BranchMergeStrategyChoices.SQUASH)
+            self.assertNotIn('Squash', ' '.join(str(r) for r in recs))
+
+    def test_main_collision_without_field_still_names_squash_under_iterative(self):
+        recs = get_merge_recommendations(
+            {'type': 'main_collision'},
+            merge_strategy=BranchMergeStrategyChoices.ITERATIVE,
+        )
+        self.assertIn('Squash', str(recs[1]))
+
+    def test_main_collision_without_field_falls_back_to_generic_guidance(self):
+        recs = get_merge_recommendations(
+            {'type': 'main_collision'},
+            merge_strategy=BranchMergeStrategyChoices.ITERATIVE,
+        )
+        self.assertEqual(len(recs), 2)
+        self.assertIn('main schema', ' '.join(str(r) for r in recs))
 
     def test_database_error_iterative_suggests_log_review_and_squash(self):
         recs = get_merge_recommendations(

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -5,6 +5,7 @@ import unittest
 import unittest.mock
 import uuid
 
+from dcim.choices import DeviceFaceChoices
 from dcim.models import (
     Cable,
     CablePath,
@@ -17,6 +18,7 @@ from dcim.models import (
     ModuleBay,
     ModuleBayTemplate,
     PortMapping,
+    Rack,
     RearPort,
     Region,
     Site,
@@ -24,6 +26,7 @@ from dcim.models import (
 )
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import connections
 from django.test import RequestFactory, SimpleTestCase, TransactionTestCase
 from django.urls import reverse
@@ -33,6 +36,7 @@ from netbox.context_managers import event_tracking
 from utilities.exceptions import AbortTransaction
 
 from netbox_branching.choices import BranchMergeStrategyChoices, BranchStatusChoices
+from netbox_branching.error_report import build_error_report, get_entry_message, get_merge_recommendations
 from netbox_branching.models import Branch, ChangeDiff
 from netbox_branching.tests.utils import provision_branch
 from netbox_branching.utilities import DELETED, _deep_merge_dict, _strip_deleted, activate_branch, diff_for_merge
@@ -1583,6 +1587,174 @@ class BaseMergeTests:
             Site.objects.filter(pk=site.pk).exists(),
             msg='commit=False must not undo the previously merged change',
         )
+
+    def _rack_collision_branch(self):
+        """
+        Build the #632 scenario: a branch device and a main device independently claiming
+        rack unit 12. Each is valid in its own schema, so nothing rejects either write and
+        no ChangeDiff conflict is recorded -- the collision only surfaces when the branch
+        CREATE is replayed against main. Returns (branch, branch_device, rack).
+        """
+        site = Site.objects.create(name='Collision Site', slug='collision-site')
+        rack = Rack.objects.create(site=site, name='Collision Rack', u_height=42)
+
+        branch = self._create_and_provision_branch()
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        with activate_branch(branch), event_tracking(request):
+            branch_device = Device.objects.create(
+                name='Branch Device',
+                site=site,
+                rack=rack,
+                device_type=self.device_type,
+                role=self.device_role,
+                position=12,
+                face=DeviceFaceChoices.FACE_FRONT,
+            )
+
+        # Main independently takes the same slot
+        Device.objects.create(
+            name='Main Device',
+            site=site,
+            rack=rack,
+            device_type=self.device_type,
+            role=self.device_role,
+            position=12,
+            face=DeviceFaceChoices.FACE_FRONT,
+        )
+
+        return branch, branch_device
+
+    def test_merge_rack_position_collision_reports_main_collision(self):
+        """
+        A merge that fails because main already occupies the rack unit must be reported as
+        a collision with main, not as an invalid value in the branch. The branch device's
+        position is perfectly valid where it lives, so telling the user to "fix" it is
+        misleading -- the object it collides with is not even visible from the branch. (#632)
+        """
+        branch, branch_device = self._rack_collision_branch()
+
+        # No conflict is detectable up front: the two devices are different objects, so
+        # there is no per-object field divergence for ChangeDiff to compare.
+        self.assertFalse(
+            ChangeDiff.objects.filter(branch=branch).exclude(conflicts=None).exists(),
+            msg='the collision is between two distinct objects, so no ChangeDiff conflict exists',
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            branch.merge(user=self.user, commit=True)
+
+        entry = build_error_report(ctx.exception)
+        self.assertEqual(entry['type'], 'main_collision')
+        self.assertEqual(entry['model'], 'device')
+        self.assertEqual(entry['field'], 'position')
+        self.assertEqual(entry['object_id'], branch_device.pk)
+        # The value and the underlying message are what make the report actionable
+        self.assertEqual(entry['value'], '12.0')
+        self.assertIn('already occupied', entry['detail'])
+
+        message = get_entry_message(entry)
+        self.assertIn('main schema', message)
+        self.assertIn('already occupied', message)
+
+        recommendations = [
+            str(r) for r in get_merge_recommendations(entry, merge_strategy=self.MERGE_STRATEGY)
+        ]
+        self.assertEqual(len(recommendations), 2)
+        joined = ' '.join(recommendations)
+        self.assertIn('main schema', joined)
+        self.assertIn('position', joined)
+        # Under iterative the branch-side route has to go through squash; under squash it
+        # already is squash. See test_branch_side_fix_needs_squash_under_iterative.
+        if self.MERGE_STRATEGY == BranchMergeStrategyChoices.SQUASH:
+            self.assertNotIn('Squash', joined)
+        else:
+            self.assertIn('Squash', recommendations[1])
+
+        # The branch survives the failed merge and can be retried
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.READY)
+
+    def test_branch_side_fix_needs_squash_under_iterative(self):
+        """
+        Moving the branch device out of the contested slot is the remedy the report offers,
+        but it only works under squash. Iterative replays the recorded changes in order, so
+        it re-applies the original CREATE at the colliding position long before reaching the
+        UPDATE that moved it -- and that intermediate state cannot exist in main anyway, as
+        the slot is guarded by a unique constraint as well as by Device.clean(). Squash
+        collapses the two into a single CREATE at the final position and succeeds. (#632)
+        """
+        branch, branch_device = self._rack_collision_branch()
+
+        with self.assertRaises(ValidationError):
+            branch.merge(user=self.user, commit=True)
+
+        # Apply the remedy: move the branch device to a free slot
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+        with activate_branch(branch), event_tracking(request):
+            device = Device.objects.get(pk=branch_device.pk)
+            device.position = 21
+            device.save()
+
+        if self.MERGE_STRATEGY == BranchMergeStrategyChoices.SQUASH:
+            branch.merge(user=self.user, commit=True)
+            self.assertEqual(Device.objects.get(pk=branch_device.pk).position, 21)
+            return
+
+        with self.assertRaises(ValidationError) as ctx:
+            branch.merge(user=self.user, commit=True)
+
+        entry = build_error_report(ctx.exception)
+        self.assertEqual(entry['type'], 'main_collision')
+        # The branch object now sits at 21, but the replayed change still carries the
+        # original 12 -- which is exactly why the retry fails.
+        self.assertEqual(entry['value'], '21.0')
+        self.assertIn('U12', entry['detail'])
+        self.assertIn(
+            'Squash',
+            str(get_merge_recommendations(entry, merge_strategy=self.MERGE_STRATEGY)[1]),
+            msg='the branch-side remedy is useless under iterative unless it names squash',
+        )
+
+    def test_merge_invalid_branch_value_is_not_reported_as_collision(self):
+        """
+        Control for the above: a value that is invalid in the branch too must keep its
+        plain validation_error classification. The probe exists to separate these two
+        cases, so a failure that reproduces inside the branch must not be relabelled.
+        """
+        site = Site.objects.create(name='Invalid Site', slug='invalid-site')
+        rack = Rack.objects.create(site=site, name='Invalid Rack', u_height=42)
+
+        branch = self._create_and_provision_branch()
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        # objects.create() skips full_clean(), so an object that could never pass validation
+        # can still be written into the branch -- a rack position with no rack face.
+        with activate_branch(branch), event_tracking(request):
+            Device.objects.create(
+                name='Faceless Device',
+                site=site,
+                rack=rack,
+                device_type=self.device_type,
+                role=self.device_role,
+                position=12,
+                face='',
+            )
+
+        with self.assertRaises(ValidationError) as ctx:
+            branch.merge(user=self.user, commit=True)
+
+        entry = build_error_report(ctx.exception)
+        self.assertEqual(entry['type'], 'validation_error')
+        self.assertEqual(entry['field'], 'face')
+        self.assertIsNone(entry['detail'])
+        self.assertIn('face', str(get_merge_recommendations(entry, merge_strategy=self.MERGE_STRATEGY)[0]))
 
 
 class IterativeMergeTestCase(BaseMergeTests, TransactionTestCase):

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1709,6 +1709,29 @@ class BaseMergeTests:
             msg='the branch-side remedy is useless under iterative unless it names squash',
         )
 
+    def test_unrelated_branch_invalidity_is_not_reported_as_collision(self):
+        """
+        The probe requires the branch object to validate cleanly, not merely to pass on the
+        field that blocked the merge: clean() raises on its first problem, so an unrelated
+        failure in the branch leaves us unable to say the merge-blocking check would have
+        passed there. Such an object is reported as a plain validation error. (#632)
+        """
+        branch, branch_device = self._rack_collision_branch()
+
+        # Break the branch copy on a different field than the one the merge trips on
+        request = RequestFactory().get(reverse('home'))
+        request.id = uuid.uuid4()
+        request.user = self.user
+        with activate_branch(branch), event_tracking(request):
+            device = Device.objects.get(pk=branch_device.pk)
+            device.face = ''
+            device.save()
+
+        with self.assertRaises(ValidationError) as ctx:
+            branch.merge(user=self.user, commit=True)
+
+        self.assertEqual(build_error_report(ctx.exception)['type'], 'validation_error')
+
     def test_merge_invalid_branch_value_is_not_reported_as_collision(self):
         """
         Control: a value that is invalid in the branch too keeps its plain validation_error

--- a/netbox_branching/tests/test_iterative_merge.py
+++ b/netbox_branching/tests/test_iterative_merge.py
@@ -1590,10 +1590,8 @@ class BaseMergeTests:
 
     def _rack_collision_branch(self):
         """
-        Build the #632 scenario: a branch device and a main device independently claiming
-        rack unit 12. Each is valid in its own schema, so nothing rejects either write and
-        no ChangeDiff conflict is recorded -- the collision only surfaces when the branch
-        CREATE is replayed against main. Returns (branch, branch_device, rack).
+        Build the #632 scenario: a branch device and a main device independently claiming rack
+        unit 12. Returns (branch, branch_device).
         """
         site = Site.objects.create(name='Collision Site', slug='collision-site')
         rack = Rack.objects.create(site=site, name='Collision Rack', u_height=42)
@@ -1629,15 +1627,12 @@ class BaseMergeTests:
 
     def test_merge_rack_position_collision_reports_main_collision(self):
         """
-        A merge that fails because main already occupies the rack unit must be reported as
-        a collision with main, not as an invalid value in the branch. The branch device's
-        position is perfectly valid where it lives, so telling the user to "fix" it is
-        misleading -- the object it collides with is not even visible from the branch. (#632)
+        A merge blocked by main's occupancy of the rack unit is reported as a collision with
+        main, not as an invalid value in the branch. (#632)
         """
         branch, branch_device = self._rack_collision_branch()
 
-        # No conflict is detectable up front: the two devices are different objects, so
-        # there is no per-object field divergence for ChangeDiff to compare.
+        # No conflict is detectable up front: different objects, so nothing diverges
         self.assertFalse(
             ChangeDiff.objects.filter(branch=branch).exclude(conflicts=None).exists(),
             msg='the collision is between two distinct objects, so no ChangeDiff conflict exists',
@@ -1651,7 +1646,6 @@ class BaseMergeTests:
         self.assertEqual(entry['model'], 'device')
         self.assertEqual(entry['field'], 'position')
         self.assertEqual(entry['object_id'], branch_device.pk)
-        # The value and the underlying message are what make the report actionable
         self.assertEqual(entry['value'], '12.0')
         self.assertIn('already occupied', entry['detail'])
 
@@ -1666,8 +1660,7 @@ class BaseMergeTests:
         joined = ' '.join(recommendations)
         self.assertIn('main schema', joined)
         self.assertIn('position', joined)
-        # Under iterative the branch-side route has to go through squash; under squash it
-        # already is squash. See test_branch_side_fix_needs_squash_under_iterative.
+        # The branch-side route needs squash unless we are already on it
         if self.MERGE_STRATEGY == BranchMergeStrategyChoices.SQUASH:
             self.assertNotIn('Squash', joined)
         else:
@@ -1679,12 +1672,9 @@ class BaseMergeTests:
 
     def test_branch_side_fix_needs_squash_under_iterative(self):
         """
-        Moving the branch device out of the contested slot is the remedy the report offers,
-        but it only works under squash. Iterative replays the recorded changes in order, so
-        it re-applies the original CREATE at the colliding position long before reaching the
-        UPDATE that moved it -- and that intermediate state cannot exist in main anyway, as
-        the slot is guarded by a unique constraint as well as by Device.clean(). Squash
-        collapses the two into a single CREATE at the final position and succeeds. (#632)
+        Moving the branch device out of the contested slot only works under squash: iterative
+        re-applies the original CREATE at the colliding position before reaching the UPDATE
+        that moved it. (#632)
         """
         branch, branch_device = self._rack_collision_branch()
 
@@ -1710,8 +1700,7 @@ class BaseMergeTests:
 
         entry = build_error_report(ctx.exception)
         self.assertEqual(entry['type'], 'main_collision')
-        # The branch object now sits at 21, but the replayed change still carries the
-        # original 12 -- which is exactly why the retry fails.
+        # Branch object is at 21 now, but the replayed change still carries the original 12
         self.assertEqual(entry['value'], '21.0')
         self.assertIn('U12', entry['detail'])
         self.assertIn(
@@ -1722,9 +1711,8 @@ class BaseMergeTests:
 
     def test_merge_invalid_branch_value_is_not_reported_as_collision(self):
         """
-        Control for the above: a value that is invalid in the branch too must keep its
-        plain validation_error classification. The probe exists to separate these two
-        cases, so a failure that reproduces inside the branch must not be relabelled.
+        Control: a value that is invalid in the branch too keeps its plain validation_error
+        classification.
         """
         site = Site.objects.create(name='Invalid Site', slug='invalid-site')
         rack = Rack.objects.create(site=site, name='Invalid Rack', u_height=42)
@@ -1734,8 +1722,7 @@ class BaseMergeTests:
         request.id = uuid.uuid4()
         request.user = self.user
 
-        # objects.create() skips full_clean(), so an object that could never pass validation
-        # can still be written into the branch -- a rack position with no rack face.
+        # objects.create() skips full_clean(), so an invalid object can still reach the branch
         with activate_branch(branch), event_tracking(request):
             Device.objects.create(
                 name='Faceless Device',


### PR DESCRIPTION
### Fixes: #632 

This is a valid conflict that the user must fix, so made a specific check for this in the merge report. photo below.  For merge even if you fix you must use squash merge as iterative merge will still have an try to replay the original conflicting ObjectChange.

When a branch object and a main object independently claim the same resource (e.g. the same rack unit), no conflict is detectable up front and the merge reported it as an invalid value in the branch - misleading, since the branch value is valid and the colliding object lives in main.

Merge validation failures are now re-checked against the branch's own schema. If the failure doesn't reproduce there, it's reported as a collision with main, quoting the underlying error and offering two real routes: resolve it in main, or change the value in the branch and merge with squash (iterative replays the original colliding value, so it fails again).

Reporting only - merge behavior is unchanged, and sync is untouched.

<img width="1351" height="727" alt="Monosnap Issue 632B Rack Collision - Merge Report | NetBox 2026-09-10 14-29-28" src="https://github.com/user-attachments/assets/6a678543-2483-406e-ad30-90a77ca69b52" />
